### PR TITLE
Fix Linux build

### DIFF
--- a/Sources/SharingGRDB/FetchKey.swift
+++ b/Sources/SharingGRDB/FetchKey.swift
@@ -1,7 +1,7 @@
 import Dependencies
+import Dispatch
 import GRDB
 import Sharing
-import SwiftUI
 
 #if canImport(Combine)
   @preconcurrency import Combine


### PR DESCRIPTION
While GRDB states that it doesn't support Linux, it does successfully build on Linux, so we should do the same.

Also discovered via SPI builds.