### PR TITLE
Correct count for number of reminders in list.

### DIFF
--- a/Examples/Reminders/RemindersLists.swift
+++ b/Examples/Reminders/RemindersLists.swift
@@ -109,7 +109,10 @@ struct RemindersListsView: View {
       try Record.fetchAll(
         db,
         RemindersList.annotated(
-          with: RemindersList.hasMany(Reminder.self).count
+          with: RemindersList
+            .hasMany(Reminder.self)
+            .filter(!Column("isCompleted"))
+            .count
         )
       )
     }


### PR DESCRIPTION
During the livestream I noticed that the count of reminders in the list view wasn't correct. It's because we are counting _all_ reminders in the list, not just the un-completed ones. So updating the query...