### PR TITLE
Updated ReminderForm to use more standard SwiftUI

### DIFF
--- a/Examples/Reminders/ReminderForm.swift
+++ b/Examples/Reminders/ReminderForm.swift
@@ -225,9 +225,9 @@ struct TagsPopover: View {
 }
 
 #Preview {
-  let (remindersList, reminder) = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
-    return try! $0.defaultDatabase.write { db in
+  let (remindersList, reminder) = try! prepareDependencies {
+    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+    return try $0.defaultDatabase.write { db in
       let remindersList = try RemindersList.fetchOne(db)!
       return (
         remindersList,

--- a/Examples/Reminders/ReminderRow.swift
+++ b/Examples/Reminders/ReminderRow.swift
@@ -127,9 +127,9 @@ struct ReminderRow: View {
 #Preview {
   var reminder: Reminder!
   var reminderList: RemindersList!
-  let _ = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
-    try! $0.defaultDatabase.read { db in
+  let _ = try! prepareDependencies {
+    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+    try $0.defaultDatabase.read { db in
       reminder = try Reminder.fetchOne(db)
       reminderList = try RemindersList.fetchOne(db)!
     }

--- a/Examples/Reminders/RemindersApp.swift
+++ b/Examples/Reminders/RemindersApp.swift
@@ -5,8 +5,8 @@ import SwiftUI
 @main
 struct RemindersApp: App {
   init() {
-    prepareDependencies {
-      $0.defaultDatabase = .appDatabase
+    try! prepareDependencies {
+      $0.defaultDatabase = try Reminders.appDatabase()
     }
   }
   

--- a/Examples/Reminders/RemindersListDetail.swift
+++ b/Examples/Reminders/RemindersListDetail.swift
@@ -8,8 +8,8 @@ struct RemindersListDetailView: View {
   @Shared private var showCompleted: Bool
   private let remindersList: RemindersList
 
-  @State var isNewReminderSheetPresented = false
-
+  @State var newReminderFormConfig = ReminderFormConfig()
+  
   @Dependency(\.defaultDatabase) private var database
 
   enum Ordering: String, CaseIterable {
@@ -72,16 +72,16 @@ struct RemindersListDetailView: View {
     }
     .navigationTitle(Text(remindersList.name))
     .navigationBarTitleDisplayMode(.large)
-    .sheet(isPresented: $isNewReminderSheetPresented) {
+    .sheet(isPresented: $newReminderFormConfig.isEditing) {
       NavigationStack {
-        ReminderFormView(remindersList: remindersList)
+        ReminderFormView(config: $newReminderFormConfig)
       }
     }
     .toolbar {
       ToolbarItem(placement: .bottomBar) {
         HStack {
           Button {
-            isNewReminderSheetPresented = true
+            newReminderFormConfig.present(remindersList: remindersList)
           } label: {
             HStack {
               Image(systemName: "plus.circle.fill")

--- a/Examples/Reminders/RemindersListDetail.swift
+++ b/Examples/Reminders/RemindersListDetail.swift
@@ -173,9 +173,9 @@ struct RemindersListDetailView: View {
 }
 
 #Preview {
-  let remindersList = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
-    return try! $0.defaultDatabase.read { db in
+  let remindersList = try! prepareDependencies {
+    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+    return try $0.defaultDatabase.read { db in
       try RemindersList.fetchOne(db)!
     }
   }

--- a/Examples/Reminders/RemindersListForm.swift
+++ b/Examples/Reminders/RemindersListForm.swift
@@ -65,7 +65,9 @@ extension Int {
 }
 
 #Preview {
-  let _ = prepareDependencies { $0.defaultDatabase = .appDatabase }
+  let _ = try! prepareDependencies {
+    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+  }
   NavigationStack {
     RemindersListForm()
   }

--- a/Examples/Reminders/RemindersListForm.swift
+++ b/Examples/Reminders/RemindersListForm.swift
@@ -11,9 +11,9 @@ struct RemindersListForm: View {
 
   init(existingList: RemindersList? = nil) {
     if let existingList {
-      _remindersList = State(wrappedValue: existingList)
+      remindersList = existingList
     } else {
-      _remindersList = State(wrappedValue: RemindersList())
+      remindersList = RemindersList()
     }
   }
 

--- a/Examples/Reminders/RemindersLists.swift
+++ b/Examples/Reminders/RemindersLists.swift
@@ -186,8 +186,8 @@ private struct ReminderGridCell: View {
 }
 
 #Preview {
-  let _ = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
+  let _ = try! prepareDependencies {
+    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
   }
   NavigationStack {
     RemindersListsView()

--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -50,73 +50,69 @@ struct ReminderTag: Codable, FetchableRecord, MutablePersistableRecord {
   var tagID: Int64?
 }
 
-extension DatabaseReader where Self == DatabaseQueue {
-  static var appDatabase: Self {
-    let databaseQueue: DatabaseQueue
-    var configuration = Configuration()
-    configuration.foreignKeysEnabled = true
-    configuration.prepareDatabase { db in
-      #if DEBUG
-        db.trace(options: .profile) {
-          print($0.expandedDescription)
-        }
-      #endif
-    }
-    if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == nil && !isTesting {
-      let path = URL.documentsDirectory.appending(component: "db.sqlite").path()
-      print("open", path)
-      databaseQueue = try! DatabaseQueue(path: path, configuration: configuration)
-    } else {
-      databaseQueue = try! DatabaseQueue(configuration: configuration)
-    }
-    var migrator = DatabaseMigrator()
+func appDatabase(inMemory: Bool = false) throws -> any DatabaseWriter {
+  let database: any DatabaseWriter
+  var configuration = Configuration()
+  configuration.foreignKeysEnabled = true
+  configuration.prepareDatabase { db in
     #if DEBUG
-      migrator.eraseDatabaseOnSchemaChange = true
+      db.trace(options: .profile) {
+        print($0.expandedDescription)
+      }
     #endif
-    defer {
-      #if DEBUG
-      migrator.registerMigration("Add mock data") { db in
-        try db.createMockData()
-      }
-      #endif
-      try! migrator.migrate(databaseQueue)
-    }
-    migrator.registerMigration("Add reminders lists table") { db in
-      try db.create(table: RemindersList.databaseTableName) { table in
-        table.autoIncrementedPrimaryKey("id")
-        table.column("color", .integer).defaults(to: 0x4a99ef).notNull()
-        table.column("name", .text).notNull()
-      }
-    }
-    migrator.registerMigration("Add reminders table") { db in
-      try db.create(table: Reminder.databaseTableName) { table in
-        table.autoIncrementedPrimaryKey("id")
-        table.column("date", .date)
-        table.column("isCompleted", .boolean).defaults(to: false).notNull()
-        table.column("isFlagged", .boolean).defaults(to: false).notNull()
-        table.column("listID", .integer)
-          .references(RemindersList.databaseTableName, column: "id", onDelete: .cascade)
-          .notNull()
-        table.column("notes", .text).notNull()
-        table.column("priority", .integer)
-        table.column("title", .text).notNull()
-      }
-    }
-    migrator.registerMigration("Add tags table") { db in
-      try db.create(table: Tag.databaseTableName) { table in
-        table.autoIncrementedPrimaryKey("id")
-        table.column("name", .text).notNull().collate(.nocase).unique()
-      }
-      try db.create(table: ReminderTag.databaseTableName) { table in
-        table.column("reminderID", .integer).notNull()
-          .references(Reminder.databaseTableName, column: "id", onDelete: .cascade)
-        table.column("tagID", .integer).notNull()
-          .references(Tag.databaseTableName, column: "id", onDelete: .cascade)
-      }
-    }
-
-    return databaseQueue
   }
+  if inMemory {
+    database = try DatabaseQueue(configuration: configuration)
+  } else {
+    let path = URL.documentsDirectory.appending(component: "db.sqlite").path()
+    print("open", path)
+    database = try DatabasePool(path: path, configuration: configuration)
+  }
+  var migrator = DatabaseMigrator()
+  #if DEBUG
+    migrator.eraseDatabaseOnSchemaChange = true
+  #endif
+  migrator.registerMigration("Add reminders lists table") { db in
+    try db.create(table: RemindersList.databaseTableName) { table in
+      table.autoIncrementedPrimaryKey("id")
+      table.column("color", .integer).defaults(to: 0x4a99ef).notNull()
+      table.column("name", .text).notNull()
+    }
+  }
+  migrator.registerMigration("Add reminders table") { db in
+    try db.create(table: Reminder.databaseTableName) { table in
+      table.autoIncrementedPrimaryKey("id")
+      table.column("date", .date)
+      table.column("isCompleted", .boolean).defaults(to: false).notNull()
+      table.column("isFlagged", .boolean).defaults(to: false).notNull()
+      table.column("listID", .integer)
+        .references(RemindersList.databaseTableName, column: "id", onDelete: .cascade)
+        .notNull()
+      table.column("notes", .text).notNull()
+      table.column("priority", .integer)
+      table.column("title", .text).notNull()
+    }
+  }
+  migrator.registerMigration("Add tags table") { db in
+    try db.create(table: Tag.databaseTableName) { table in
+      table.autoIncrementedPrimaryKey("id")
+      table.column("name", .text).notNull().collate(.nocase).unique()
+    }
+    try db.create(table: ReminderTag.databaseTableName) { table in
+      table.column("reminderID", .integer).notNull()
+        .references(Reminder.databaseTableName, column: "id", onDelete: .cascade)
+      table.column("tagID", .integer).notNull()
+        .references(Tag.databaseTableName, column: "id", onDelete: .cascade)
+    }
+  }
+  #if DEBUG
+    migrator.registerMigration("Add mock data") { db in
+      try db.createMockData()
+    }
+  #endif
+  try migrator.migrate(database)
+
+  return database
 }
 
 #if DEBUG

--- a/Examples/Reminders/SearchReminders.swift
+++ b/Examples/Reminders/SearchReminders.swift
@@ -182,8 +182,8 @@ private func searchQueryBase(searchText: String) -> QueryInterfaceRequest<Remind
 
 #Preview {
   @Previewable @State var searchText = "take"
-  let _ = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
+  let _ = try! prepareDependencies {
+    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
   }
 
   NavigationStack {

--- a/Examples/SyncUps/App.swift
+++ b/Examples/SyncUps/App.swift
@@ -80,7 +80,7 @@ struct AppView: View {
 
 #Preview("Happy path") {
   let _ = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
+    $0.defaultDatabase = SyncUps.appDatabase(inMemory: true)
   }
   AppView(model: AppModel())
 }

--- a/Examples/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUpDetail.swift
@@ -289,7 +289,7 @@ struct MeetingView: View {
 
 #Preview {
   let _ = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
+    $0.defaultDatabase = SyncUps.appDatabase(inMemory: true)
   }
   @Dependency(\.defaultDatabase) var database
   let syncUp = try! database.read { db in

--- a/Examples/SyncUps/SyncUpsApp.swift
+++ b/Examples/SyncUps/SyncUpsApp.swift
@@ -6,8 +6,8 @@ struct SyncUpsApp: App {
   static let model = AppModel()
 
   init() {
-    prepareDependencies {
-      $0.defaultDatabase = .appDatabase
+    try! prepareDependencies {
+      $0.defaultDatabase = try SyncUps.appDatabase()
     }
   }
 

--- a/Examples/SyncUps/SyncUpsList.swift
+++ b/Examples/SyncUps/SyncUpsList.swift
@@ -102,7 +102,9 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
 }
 
 #Preview {
-  let _ = prepareDependencies { $0.defaultDatabase = .appDatabase }
+  let _ = prepareDependencies {
+    $0.defaultDatabase = SyncUps.appDatabase(inMemory: true)
+  }
   NavigationStack {
     SyncUpsList(model: SyncUpsListModel())
   }

--- a/Sources/SharingGRDB/Documentation.docc/Articles/DynamicQueries.md
+++ b/Sources/SharingGRDB/Documentation.docc/Articles/DynamicQueries.md
@@ -57,13 +57,17 @@ struct ContentView: View {
     List {
       // ...
     }
-    .onChange(of: [filterDate, order] as [AnyHashable], initial: true) {
-      updateQuery()
+    .task(id: [filter, ordering] as [AnyHashable]) {
+      await updateQuery()
     }
   }
 
-  private func updateQuery() {
-    $items.load(.fetch(Items(filterDate: filterDate, order: order)))
+  private func updateQuery() async {
+    do {
+      try await $items.load(.fetch(Items(filterDate: filterDate, order: order)))
+    } catch {
+      // Handle error...
+    }
   }
 
   private struct Items: FetchKeyRequest {


### PR DESCRIPTION
Replaced all of `ReminderForm`'s `State(wrappedValue:`) with a `Binding`. This made it possible to remove ReminderForm's custom init. Added `ReminderFormConfig` for the form's data and logic. Change from `.sheet(item:)` which is for static content to `.sheet(isPresented:)` which is for dynamic. Replaced the Environment var dismiss with isPresented = false.

There are other instances of `State(wrappedValue:)` in the project which could also be replaced with Binding.