### PR TITLE
No need to initialize State directly.

### DIFF
--- a/Examples/Reminders/RemindersListForm.swift
+++ b/Examples/Reminders/RemindersListForm.swift
@@ -11,9 +11,9 @@ struct RemindersListForm: View {
 
   init(existingList: RemindersList? = nil) {
     if let existingList {
-      _remindersList = State(wrappedValue: existingList)
+      remindersList = existingList
     } else {
-      _remindersList = State(wrappedValue: RemindersList())
+      remindersList = RemindersList()
     }
   }
 


### PR DESCRIPTION
Came across this while responding to #13. We are initializing a bunch of `State` values that weren't really necessary. Think this was just an artifact of us being deep in exploring how to use `@SharedReader` in SwiftUI views and we didn't audit it before releasing.