### PR TITLE
Update examples/docs to use `DatabasePool` for non-in-memory

### DIFF
--- a/Examples/Reminders/ReminderForm.swift
+++ b/Examples/Reminders/ReminderForm.swift
@@ -225,9 +225,9 @@ struct TagsPopover: View {
 }
 
 #Preview {
-  let (remindersList, reminder) = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
-    return try! $0.defaultDatabase.write { db in
+  let (remindersList, reminder) = try! prepareDependencies {
+    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+    return try $0.defaultDatabase.write { db in
       let remindersList = try RemindersList.fetchOne(db)!
       return (
         remindersList,

--- a/Examples/Reminders/ReminderRow.swift
+++ b/Examples/Reminders/ReminderRow.swift
@@ -127,9 +127,9 @@ struct ReminderRow: View {
 #Preview {
   var reminder: Reminder!
   var reminderList: RemindersList!
-  let _ = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
-    try! $0.defaultDatabase.read { db in
+  let _ = try! prepareDependencies {
+    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+    try $0.defaultDatabase.read { db in
       reminder = try Reminder.fetchOne(db)
       reminderList = try RemindersList.fetchOne(db)!
     }

--- a/Examples/Reminders/RemindersApp.swift
+++ b/Examples/Reminders/RemindersApp.swift
@@ -5,8 +5,8 @@ import SwiftUI
 @main
 struct RemindersApp: App {
   init() {
-    prepareDependencies {
-      $0.defaultDatabase = .appDatabase
+    try! prepareDependencies {
+      $0.defaultDatabase = try Reminders.appDatabase(inMemory: false)
     }
   }
   

--- a/Examples/Reminders/RemindersListDetail.swift
+++ b/Examples/Reminders/RemindersListDetail.swift
@@ -173,9 +173,9 @@ struct RemindersListDetailView: View {
 }
 
 #Preview {
-  let remindersList = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
-    return try! $0.defaultDatabase.read { db in
+  let remindersList = try! prepareDependencies {
+    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+    return try $0.defaultDatabase.read { db in
       try RemindersList.fetchOne(db)!
     }
   }

--- a/Examples/Reminders/RemindersListForm.swift
+++ b/Examples/Reminders/RemindersListForm.swift
@@ -65,7 +65,9 @@ extension Int {
 }
 
 #Preview {
-  let _ = prepareDependencies { $0.defaultDatabase = .appDatabase }
+  let _ = try! prepareDependencies {
+    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+  }
   NavigationStack {
     RemindersListForm()
   }

--- a/Examples/Reminders/RemindersLists.swift
+++ b/Examples/Reminders/RemindersLists.swift
@@ -186,8 +186,8 @@ private struct ReminderGridCell: View {
 }
 
 #Preview {
-  let _ = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
+  let _ = try! prepareDependencies {
+    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
   }
   NavigationStack {
     RemindersListsView()

--- a/Examples/Reminders/SearchReminders.swift
+++ b/Examples/Reminders/SearchReminders.swift
@@ -182,8 +182,8 @@ private func searchQueryBase(searchText: String) -> QueryInterfaceRequest<Remind
 
 #Preview {
   @Previewable @State var searchText = "take"
-  let _ = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
+  let _ = try! prepareDependencies {
+    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
   }
 
   NavigationStack {

--- a/Examples/SyncUps/App.swift
+++ b/Examples/SyncUps/App.swift
@@ -80,7 +80,7 @@ struct AppView: View {
 
 #Preview("Happy path") {
   let _ = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
+    $0.defaultDatabase = SyncUps.appDatabase(inMemory: true)
   }
   AppView(model: AppModel())
 }

--- a/Examples/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUpDetail.swift
@@ -289,7 +289,7 @@ struct MeetingView: View {
 
 #Preview {
   let _ = prepareDependencies {
-    $0.defaultDatabase = .appDatabase
+    $0.defaultDatabase = SyncUps.appDatabase(inMemory: true)
   }
   @Dependency(\.defaultDatabase) var database
   let syncUp = try! database.read { db in

--- a/Examples/SyncUps/SyncUpsApp.swift
+++ b/Examples/SyncUps/SyncUpsApp.swift
@@ -6,8 +6,8 @@ struct SyncUpsApp: App {
   static let model = AppModel()
 
   init() {
-    prepareDependencies {
-      $0.defaultDatabase = .appDatabase
+    try! prepareDependencies {
+      $0.defaultDatabase = try SyncUps.appDatabase(inMemory: false)
     }
   }
 

--- a/Examples/SyncUps/SyncUpsList.swift
+++ b/Examples/SyncUps/SyncUpsList.swift
@@ -102,7 +102,9 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
 }
 
 #Preview {
-  let _ = prepareDependencies { $0.defaultDatabase = .appDatabase }
+  let _ = prepareDependencies {
+    $0.defaultDatabase = SyncUps.appDatabase(inMemory: true)
+  }
   NavigationStack {
     SyncUpsList(model: SyncUpsListModel())
   }


### PR DESCRIPTION
Database pools enable WAL mode and better multithreaded performance, so let's steer folks in that direction in the demo apps.

(I didn't update the case studies app since each study is very small and think we should do the minimal setup required.)