### PR TITLE
Update database prep examples/docs to use dependency context

### DIFF
--- a/Examples/Reminders/ReminderForm.swift
+++ b/Examples/Reminders/ReminderForm.swift
@@ -226,7 +226,7 @@ struct TagsPopover: View {
 
 #Preview {
   let (remindersList, reminder) = try! prepareDependencies {
-    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+    $0.defaultDatabase = try Reminders.appDatabase()
     return try $0.defaultDatabase.write { db in
       let remindersList = try RemindersList.fetchOne(db)!
       return (

--- a/Examples/Reminders/ReminderRow.swift
+++ b/Examples/Reminders/ReminderRow.swift
@@ -128,7 +128,7 @@ struct ReminderRow: View {
   var reminder: Reminder!
   var reminderList: RemindersList!
   let _ = try! prepareDependencies {
-    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+    $0.defaultDatabase = try Reminders.appDatabase()
     try $0.defaultDatabase.read { db in
       reminder = try Reminder.fetchOne(db)
       reminderList = try RemindersList.fetchOne(db)!

--- a/Examples/Reminders/RemindersListDetail.swift
+++ b/Examples/Reminders/RemindersListDetail.swift
@@ -174,7 +174,7 @@ struct RemindersListDetailView: View {
 
 #Preview {
   let remindersList = try! prepareDependencies {
-    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+    $0.defaultDatabase = try Reminders.appDatabase()
     return try $0.defaultDatabase.read { db in
       try RemindersList.fetchOne(db)!
     }

--- a/Examples/Reminders/RemindersListForm.swift
+++ b/Examples/Reminders/RemindersListForm.swift
@@ -66,7 +66,7 @@ extension Int {
 
 #Preview {
   let _ = try! prepareDependencies {
-    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+    $0.defaultDatabase = try Reminders.appDatabase()
   }
   NavigationStack {
     RemindersListForm()

--- a/Examples/Reminders/RemindersLists.swift
+++ b/Examples/Reminders/RemindersLists.swift
@@ -187,7 +187,7 @@ private struct ReminderGridCell: View {
 
 #Preview {
   let _ = try! prepareDependencies {
-    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+    $0.defaultDatabase = try Reminders.appDatabase()
   }
   NavigationStack {
     RemindersListsView()

--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -50,7 +50,7 @@ struct ReminderTag: Codable, FetchableRecord, MutablePersistableRecord {
   var tagID: Int64?
 }
 
-func appDatabase(inMemory: Bool = false) throws -> any DatabaseWriter {
+func appDatabase() throws -> any DatabaseWriter {
   let database: any DatabaseWriter
   var configuration = Configuration()
   configuration.foreignKeysEnabled = true
@@ -61,12 +61,13 @@ func appDatabase(inMemory: Bool = false) throws -> any DatabaseWriter {
       }
     #endif
   }
-  if inMemory {
-    database = try DatabaseQueue(configuration: configuration)
-  } else {
+  @Dependency(\.context) var context
+  if context == .live {
     let path = URL.documentsDirectory.appending(component: "db.sqlite").path()
     print("open", path)
     database = try DatabasePool(path: path, configuration: configuration)
+  } else {
+    database = try DatabaseQueue(configuration: configuration)
   }
   var migrator = DatabaseMigrator()
   #if DEBUG

--- a/Examples/Reminders/SearchReminders.swift
+++ b/Examples/Reminders/SearchReminders.swift
@@ -183,7 +183,7 @@ private func searchQueryBase(searchText: String) -> QueryInterfaceRequest<Remind
 #Preview {
   @Previewable @State var searchText = "take"
   let _ = try! prepareDependencies {
-    $0.defaultDatabase = try Reminders.appDatabase(inMemory: true)
+    $0.defaultDatabase = try Reminders.appDatabase()
   }
 
   NavigationStack {

--- a/Examples/SyncUps/App.swift
+++ b/Examples/SyncUps/App.swift
@@ -80,7 +80,7 @@ struct AppView: View {
 
 #Preview("Happy path") {
   let _ = prepareDependencies {
-    $0.defaultDatabase = SyncUps.appDatabase(inMemory: true)
+    $0.defaultDatabase = SyncUps.appDatabase()
   }
   AppView(model: AppModel())
 }

--- a/Examples/SyncUps/Schema.swift
+++ b/Examples/SyncUps/Schema.swift
@@ -87,7 +87,7 @@ enum Theme: String, CaseIterable, Codable, Hashable, Identifiable, DatabaseValue
   }
 }
 
-func appDatabase(inMemory: Bool = false) throws -> any DatabaseWriter {
+func appDatabase() throws -> any DatabaseWriter {
   let database: any DatabaseWriter
   var configuration = Configuration()
   configuration.foreignKeysEnabled = true
@@ -98,12 +98,13 @@ func appDatabase(inMemory: Bool = false) throws -> any DatabaseWriter {
       }
     #endif
   }
-  if inMemory {
-    database = try DatabaseQueue(configuration: configuration)
-  } else {
+  @Dependency(\.context) var context
+  if context == .live {
     let path = URL.documentsDirectory.appending(component: "db.sqlite").path()
     print("open", path)
     database = try DatabasePool(path: path, configuration: configuration)
+  } else {
+    database = try DatabaseQueue(configuration: configuration)
   }
   var migrator = DatabaseMigrator()
   #if DEBUG

--- a/Examples/SyncUps/SyncUpDetail.swift
+++ b/Examples/SyncUps/SyncUpDetail.swift
@@ -289,7 +289,7 @@ struct MeetingView: View {
 
 #Preview {
   let _ = prepareDependencies {
-    $0.defaultDatabase = SyncUps.appDatabase(inMemory: true)
+    $0.defaultDatabase = SyncUps.appDatabase()
   }
   @Dependency(\.defaultDatabase) var database
   let syncUp = try! database.read { db in

--- a/Examples/SyncUps/SyncUpsList.swift
+++ b/Examples/SyncUps/SyncUpsList.swift
@@ -103,7 +103,7 @@ extension LabelStyle where Self == TrailingIconLabelStyle {
 
 #Preview {
   let _ = prepareDependencies {
-    $0.defaultDatabase = SyncUps.appDatabase(inMemory: true)
+    $0.defaultDatabase = SyncUps.appDatabase()
   }
   NavigationStack {
     SyncUpsList(model: SyncUpsListModel())


### PR DESCRIPTION
Using `inMemory` explicitly unfortunately opens you up to preview crashes at the app entry point where it attempts to open a connection to a file, so let's rely on `@Dependency(\.context)` instead.