### PR TITLE
Reminders: Animation Fixes

### DIFF
--- a/Examples/Reminders/ReminderForm.swift
+++ b/Examples/Reminders/ReminderForm.swift
@@ -32,8 +32,18 @@ struct ReminderFormView: View {
   var body: some View {
     Form {
       TextField("Title", text: $reminder.title)
-      TextEditor(text: $reminder.notes)
-        .lineLimit(4)
+
+      ZStack {
+        if reminder.notes.isEmpty {
+          TextEditor(text: .constant("Notes"))
+            .foregroundStyle(.placeholder)
+            .accessibilityHidden(true, isEnabled: false)
+        }
+
+        TextEditor(text: $reminder.notes)
+      }
+      .lineLimit(4)
+      .padding([.leading, .trailing], -5)
 
       Section {
         Button {

--- a/Examples/Reminders/RemindersListDetail.swift
+++ b/Examples/Reminders/RemindersListDetail.swift
@@ -4,13 +4,11 @@ import SwiftUI
 
 struct RemindersListDetailView: View {
   @State.SharedReader private var remindersState: [Reminders.Record]
-  @Shared private var ordering: Ordering
-  @Shared private var showCompleted: Bool
+  @AppStorage private var ordering: Ordering
+  @AppStorage private var showCompleted: Bool
   private let remindersList: RemindersList
 
   @State var isNewReminderSheetPresented = false
-
-  @Dependency(\.defaultDatabase) private var database
 
   enum Ordering: String, CaseIterable {
     case dueDate = "Due Date"
@@ -36,9 +34,9 @@ struct RemindersListDetailView: View {
     self.remindersList = remindersList
     _remindersState = State.SharedReader(value: [])
     if let listID = remindersList.id {
-      _ordering = Shared(wrappedValue: .dueDate, .appStorage("ordering_list_\(listID)"))
-      _showCompleted = Shared(wrappedValue: false, .appStorage("show_completed_list_\(listID)"))
-      $remindersState = SharedReader(
+      _ordering = AppStorage(wrappedValue: .dueDate, "ordering_list_\(listID)")
+      _showCompleted = AppStorage(wrappedValue: false, "show_completed_list_\(listID)")
+      _remindersState = State.SharedReader(
         .fetch(
           Reminders(
             listID: listID,
@@ -98,7 +96,7 @@ struct RemindersListDetailView: View {
           Menu {
             ForEach(Ordering.allCases, id: \.self) { ordering in
               Button {
-                $ordering.withLock { $0 = ordering }
+                self.ordering = ordering
               } label: {
                 Text(ordering.rawValue)
                 ordering.icon
@@ -110,7 +108,7 @@ struct RemindersListDetailView: View {
             Image(systemName: "arrow.up.arrow.down")
           }
           Button {
-            $showCompleted.withLock { $0.toggle() }
+            showCompleted.toggle()
           } label: {
             Text(showCompleted ? "Hide Completed" : "Show Completed")
             Image(systemName: showCompleted ? "eye.slash.fill" : "eye")

--- a/SharingGRDB.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SharingGRDB.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "2f5ab6e091dd032b63dacbda052405756010dc3b",
-        "version" : "1.1.0"
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "10ba53dd428aed9fc4a1543d3271860a6d4b8dd2",
-        "version" : "2.3.0"
+        "revision" : "6060619646deff09f0a785e17448441fdf2c146c",
+        "version" : "2.3.2"
       }
     },
     {


### PR DESCRIPTION
Because Reminders is all in the view, meaning new `Shared` instances can pop in during body computations, things like animation are a little less stable. This PR doesn't 100% fix things, but it does make things much more reliable.