### PR TITLE
Include database identity in fetch key

### DIFF
--- a/Sources/SharingGRDB/FetchKey.swift
+++ b/Sources/SharingGRDB/FetchKey.swift
@@ -162,7 +162,9 @@ public struct FetchKey<Value: Sendable>: SharedReaderKey {
 
   public typealias ID = FetchKeyID
 
-  public var id: ID { ID(rawValue: request) }
+  public var id: ID {
+    ID(database: database, request: request)
+  }
 
   init(
     request: some FetchKeyRequest<Value>,
@@ -266,17 +268,24 @@ public struct FetchKey<Value: Sendable>: SharedReaderKey {
 
 /// A value that uniquely identifies a fetch key.
 public struct FetchKeyID: Hashable {
-  fileprivate let rawValue: AnyHashableSendable
-  fileprivate let typeID: ObjectIdentifier
+  fileprivate let databaseID: ObjectIdentifier
+  fileprivate let request: AnyHashableSendable
+  fileprivate let requestTypeID: ObjectIdentifier
 
-  fileprivate init(rawValue: some FetchKeyRequest) {
-    self.rawValue = AnyHashableSendable(rawValue)
-    self.typeID = ObjectIdentifier(type(of: rawValue))
+  fileprivate init(
+    database: any DatabaseReader,
+    request: some FetchKeyRequest
+  ) {
+    self.databaseID = ObjectIdentifier(database)
+    self.request = AnyHashableSendable(request)
+    self.requestTypeID = ObjectIdentifier(type(of: request))
+
   }
 
   public func hash(into hasher: inout Hasher) {
-    hasher.combine(rawValue)
-    hasher.combine(typeID)
+    hasher.combine(databaseID)
+    hasher.combine(request)
+    hasher.combine(requestTypeID)
   }
 }
 

--- a/Tests/SharingGRDBTests/SharingGRDBTests.swift
+++ b/Tests/SharingGRDBTests/SharingGRDBTests.swift
@@ -39,4 +39,71 @@ import Testing
       #expect(error.message == #"near "SELEC": syntax error"#)
     }
   }
+
+  @Test func fetchWithTwoDatabaseConnections() async throws {
+    try await withDependencies {
+      $0.defaultDatabase = try .database
+    } operation: {
+      @SharedReader(.fetchAll(sql: "SELECT * FROM records")) var records1: [Record] = []
+      try await Task.sleep(nanoseconds: 100_000_000)
+      #expect(records1.map(\.id) == [1, 2, 3])
+
+      try await withDependencies {
+        $0.defaultDatabase = try .database
+      } operation: {
+        @Dependency(\.defaultDatabase) var database2
+        @SharedReader(.fetchAll(sql: "SELECT * FROM records")) var records2: [Record] = []
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(records2.map(\.id) == [1, 2, 3])
+        try await database2.write { db in
+          _ = try Record.deleteOne(db, key: 1)
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(records1.map(\.id) == [1, 2, 3])
+        #expect(records2.map(\.id) == [2, 3])
+      }
+
+      try await $records1.load()
+      #expect(records1.map(\.id) == [2, 3])
+    }
+  }
+
+  @Test(.dependency(\.defaultDatabase, try .database))
+  func fetchIDHashValue() async throws {
+    let fetchKey1: some SharedReaderKey<Void> = .fetch(Fetch1())
+    let fetchKey2: some SharedReaderKey<Void> = .fetch(Fetch2())
+    #expect(fetchKey1.id.hashValue != fetchKey2.id.hashValue)
+  }
+}
+
+fileprivate struct Fetch1: FetchKeyRequest {
+  func fetch(_ db: Database) throws {
+  }
+}
+fileprivate struct Fetch2: FetchKeyRequest {
+  func fetch(_ db: Database) throws {
+  }
+}
+
+fileprivate struct Record: Codable, Equatable, FetchableRecord, MutablePersistableRecord {
+  static let databaseTableName = "records"
+  let id: Int
+}
+extension DatabaseWriter where Self == DatabaseQueue {
+  fileprivate static var database: DatabaseQueue {
+    get throws {
+      let database = try DatabaseQueue(named: "db")
+      var migrator = DatabaseMigrator()
+      migrator.registerMigration("Up") { db in
+        try db.create(table: "records") { table in
+          table.column("id", .integer).primaryKey(autoincrement: true)
+        }
+        for index in 1...3 {
+          _ = try Record(id: index).inserted(db)
+        }
+      }
+      try migrator.migrate(database)
+      return database
+    }
+  }
 }


### PR DESCRIPTION
A discussion highlighted this omission:

https://github.com/pointfreeco/sharing-grdb/discussions/25

We knew this was needed but it must've slipped through the cracks before release.