### PR TITLE
Update README.md to point to the latest release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Sharing. Check out [this](./Examples) directory to see them all, including:
 The documentation for releases and `main` are available here:
 
 * [`main`](https://swiftpackageindex.com/pointfreeco/sharing-grdb/main/documentation/sharinggrdb/)
-* [0.1.1](https://swiftpackageindex.com/pointfreeco/sharing-grdb/0.1.1/documentation/sharinggrdb/)
+* [0.1.x](https://swiftpackageindex.com/pointfreeco/sharing-grdb/~/documentation/sharinggrdb/)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Sharing. Check out [this](./Examples) directory to see them all, including:
 The documentation for releases and `main` are available here:
 
 * [`main`](https://swiftpackageindex.com/pointfreeco/sharing-grdb/main/documentation/sharinggrdb/)
-* [0.1.0](https://swiftpackageindex.com/pointfreeco/sharing-grdb/0.1.0/documentation/sharinggrdb/)
+* [0.1.1](https://swiftpackageindex.com/pointfreeco/sharing-grdb/0.1.1/documentation/sharinggrdb/)
 
 ## Installation
 


### PR DESCRIPTION
Quick fix to point the readme link to the latest release (0.1.1) docs.