### PR TITLE
Improve type-inference for #sql.

### DIFF
--- a/Sources/SharingGRDBCore/Documentation.docc/Articles/Fetching.md
+++ b/Sources/SharingGRDBCore/Documentation.docc/Articles/Fetching.md
@@ -73,13 +73,8 @@ learn more, be sure to check out the [documentation][sq-getting-started] of Stru
 You can even execute a SQL string to populate the data in your features:
 
 ```swift
-@FetchAll(
-  #sql(
-    "SELECT * FROM reminders where isCompleted ORDER BY title DESC",
-    as: Reminder.self
-  )
-)
-var completedReminders
+@FetchAll(#sql("SELECT * FROM reminders where isCompleted ORDER BY title DESC"))
+var completedReminders: [Reminder]
 ```
 
 This uses the `#sql` macro for constructing [safe SQL strings][sq-safe-sql-strings]. You are 
@@ -94,11 +89,10 @@ description of your schema to prevent accidental typos:
     FROM \(Reminder.self)
     WHERE \(Reminder.isCompleted)
     ORDER BY \(Reminder.title) DESC
-    """,
-    as: Reminder.self
+    """
   )
 )
-var completedReminders
+var completedReminders: [Reminder]
 ```
 
 These interpolations are completely safe to do because they are statically known at compile time,
@@ -186,7 +180,7 @@ var completedRemindersCount = 0
 You can use the `#sql` macro with `@FetchOne` to execute a safe SQL string:
 
 ```swift
-@FetchOne(#sql("SELECT count(*) FROM reminders WHERE isCompleted", as: Int.self))
+@FetchOne(#sql("SELECT count(*) FROM reminders WHERE isCompleted"))
 var completedRemindersCount = 0
 ```
 

--- a/Sources/SharingGRDBCore/FetchAll.swift
+++ b/Sources/SharingGRDBCore/FetchAll.swift
@@ -164,6 +164,30 @@ public struct FetchAll<Element: Sendable>: Sendable {
   ///   - statement: A query associated with the wrapped value.
   ///   - database: The database to read from. A value of `nil` will use the default database
   ///     (`@Dependency(\.defaultDatabase)`).
+  public init<S: StructuredQueriesCore.Statement<Element>>(
+    wrappedValue: [Element] = [],
+    _ statement: S,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+    Element: QueryRepresentable,
+    Element == S.QueryValue.QueryOutput
+  {
+    sharedReader = SharedReader(
+      wrappedValue: wrappedValue,
+      .fetch(
+        FetchAllStatementValueRequest(statement: statement),
+        database: database
+      )
+    )
+  }
+
+  /// Initializes this property with a query associated with the wrapped value.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
   @_disfavoredOverload
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
@@ -386,6 +410,34 @@ extension FetchAll {
   where
     Element == V.QueryOutput,
     V.QueryOutput: Sendable
+  {
+    sharedReader = SharedReader(
+      wrappedValue: wrappedValue,
+      .fetch(
+        FetchAllStatementValueRequest(statement: statement),
+        database: database,
+        scheduler: scheduler
+      )
+    )
+  }
+
+  /// Initializes this property with a query associated with the wrapped value.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  public init<S: StructuredQueriesCore.Statement<Element>>(
+    wrappedValue: [Element] = [],
+    _ statement: S,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+  Element: QueryRepresentable,
+  Element == S.QueryValue.QueryOutput
   {
     sharedReader = SharedReader(
       wrappedValue: wrappedValue,
@@ -655,6 +707,34 @@ extension FetchAll: Equatable where Element: Equatable {
     where
       Element == V.QueryOutput,
       V.QueryOutput: Sendable
+    {
+      sharedReader = SharedReader(
+        wrappedValue: wrappedValue,
+        .fetch(
+          FetchAllStatementValueRequest(statement: statement),
+          database: database,
+          animation: animation
+        )
+      )
+    }
+
+    /// Initializes this property with a query associated with the wrapped value.
+    ///
+    /// - Parameters:
+    ///   - statement: A query associated with the wrapped value.
+    ///   - database: The database to read from. A value of `nil` will use the default database
+    ///     (`@Dependency(\.defaultDatabase)`).
+    ///   - animation: The animation to use for user interface changes that result from changes to
+    ///     the fetched results.
+    public init<S: StructuredQueriesCore.Statement<Element>>(
+      wrappedValue: [Element] = [],
+      _ statement: S,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+    Element: QueryRepresentable,
+    Element == S.QueryValue.QueryOutput
     {
       sharedReader = SharedReader(
         wrappedValue: wrappedValue,

--- a/Tests/SharingGRDBTests/SharingGRDBTests.swift
+++ b/Tests/SharingGRDBTests/SharingGRDBTests.swift
@@ -13,7 +13,7 @@ import Testing
     try await withDependencies {
       $0.defaultDatabase = try DatabaseQueue()
     } operation: {
-      @FetchOne(#sql("SELECT 1", as: Bool.self)) var bool = false
+      @FetchOne(#sql("SELECT 1")) var bool = false
       try await Task.sleep(nanoseconds: 100_000_000)
       #expect(bool)
       #expect($bool.loadError == nil)
@@ -34,7 +34,7 @@ import Testing
     try await withDependencies {
       $0.defaultDatabase = try DatabaseQueue()
     } operation: {
-      @FetchOne(#sql("SELEC 1", as: Bool.self)) var bool = false
+      @FetchOne(#sql("SELEC 1")) var bool = false
       #expect(bool == false)
       try await Task.sleep(nanoseconds: 100_000_000)
       #expect($bool.loadError is DatabaseError?)


### PR DESCRIPTION
We can now do this:

```swift
@FetchAll(#sql("…")) var results: [Result]
```

…instead of this:

```swift
@FetchAll(#sql("…", as: Result.self)) var results
```