### PR TITLE
Surface `@FetchAll.load()`, etc.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: macOS
     strategy:
       matrix:
-        xcode: ['16.1']
+        xcode: ['16.3']
         config: ['debug', 'release']
     runs-on: macos-15
     steps:

--- a/Sources/SharingGRDBCore/Fetch.swift
+++ b/Sources/SharingGRDBCore/Fetch.swift
@@ -54,6 +54,11 @@ public struct Fetch<Value: Sendable>: Sendable {
     sharedReader.isLoading
   }
 
+  /// Reloads data from the database.
+  public func load() async throws {
+    try await sharedReader.load()
+  }
+
   #if canImport(Combine)
     /// A publisher that emits events when the database observes changes to the query.
     public var publisher: some Publisher<Value, Never> {

--- a/Sources/SharingGRDBCore/FetchAll.swift
+++ b/Sources/SharingGRDBCore/FetchAll.swift
@@ -56,6 +56,11 @@ public struct FetchAll<Element: Sendable>: Sendable {
     sharedReader.isLoading
   }
 
+  /// Reloads data from the database.
+  public func load() async throws {
+    try await sharedReader.load()
+  }
+
   #if canImport(Combine)
     /// A publisher that emits events when the database observes changes to the query.
     public var publisher: some Publisher<[Element], Never> {

--- a/Sources/SharingGRDBCore/FetchOne.swift
+++ b/Sources/SharingGRDBCore/FetchOne.swift
@@ -54,6 +54,11 @@ public struct FetchOne<Value: Sendable>: Sendable {
     sharedReader.isLoading
   }
 
+  /// Reloads data from the database.
+  public func load() async throws {
+    try await sharedReader.load()
+  }
+
   #if canImport(Combine)
     /// A publisher that emits events when the database observes changes to the query.
     public var publisher: some Publisher<Value, Never> {


### PR DESCRIPTION
While database observation should automatically refresh things, there are cases when you may want to refresh things manually, like external changes or in tests to avoid a thread hop.