### PR TITLE
fix linux build by importing GRDBSQLite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,20 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run ${{ matrix.config }} tests
         run: swift test -c ${{ matrix.config }}
+
+  linux:
+    name: Linux
+    strategy:
+      matrix:
+        swift:
+          - '6.0'
+    runs-on: ubuntu-latest
+    container: swift:${{ matrix.swift }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Build Dependencies
+        run: |
+          apt-get update
+          apt-get install -y libsqlite3-dev
+      - name: Build
+        run: swift build

--- a/Sources/StructuredQueriesGRDBCore/QueryCursor.swift
+++ b/Sources/StructuredQueriesGRDBCore/QueryCursor.swift
@@ -1,6 +1,6 @@
 import Foundation
 import GRDB
-import SQLite3
+import GRDBSQLite
 import StructuredQueriesCore
 
 /// A cursor of a structured query.

--- a/Sources/StructuredQueriesGRDBCore/SQLiteQueryDecoder.swift
+++ b/Sources/StructuredQueriesGRDBCore/SQLiteQueryDecoder.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import GRDBSQLite
 import StructuredQueriesCore
 
 @usableFromInline

--- a/Sources/StructuredQueriesGRDBCore/Statement+GRDB.swift
+++ b/Sources/StructuredQueriesGRDBCore/Statement+GRDB.swift
@@ -1,5 +1,5 @@
 import GRDB
-import SQLite3
+import GRDBSQLite
 import StructuredQueriesCore
 
 extension StructuredQueriesCore.Statement {


### PR DESCRIPTION
I saw that the linux build failed and wondered if we should rely on the GRDBSQLite module instead of raw SQLite3.
From what I understand, that should resolve to SQLite3 on Darwin, but use libsqlite3 on Linux.

Also, I copied over the Linux pieces from [swift-sharing](https://github.com/pointfreeco/swift-sharing/blob/main/.github/workflows/ci.yml) & added installing sqlite.

Let me know what you think & happy to adjust!