### PR TITLE
Better document modules/installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,29 @@ You can add SharingGRDB to an Xcode project by adding it to your project as a pa
 
 > https://github.com/pointfreeco/sharing-grdb
 
+And adding the `SharingGRDB` product to your target.
+
+> [!TIP]
+> SharingGRDB's primary product is the `SharingGRDB` module, which includes all of the library's
+> functionality, including the `@Fetch` family of property wrappers, the `@Table` macro, and tools
+> for driving StructuredQueries using GRDB. This is the module that most library users should depend
+> on.
+>
+> If you are a library author that wishes to extend SharingGRDB with additional functionality, you
+> may want to depend on a different module:
+>
+>   * `SharingGRDBCore`: This product includes everything in `SharingGRDB` _except_ the macros
+>     (`@Table`, `#sql`, _etc._). This module can be imported to extend SharingGRDB with additional
+>     functionality without forcing the heavyweight dependency of SwiftSyntax on your users.
+>   * `StructuredQueriesGRDB`: This product includes everything in `SharingGRDB` _except_ the
+>     `@Fetch` family of property wrappers. It can be imported if you want to extend
+>     StructuredQueries' GRDB driver but do not need access to observation tools provided by
+>     Sharing.
+>   * `StructuredQueriesGRDBCore`: This product includes everything in `StructuredQueriesGRDB`
+>     _except_ the macros. This module can be imported to extend StructuredQueries' GRDB driver with
+>     additional functionality without forcing the heavyweight dependency of SwiftSyntax on your
+>     users.
+
 If you want to use SharingGRDB in a [SwiftPM](https://swift.org/package-manager/) project, it's as
 simple as adding it to your `Package.swift`:
 

--- a/README.md
+++ b/README.md
@@ -292,11 +292,11 @@ The documentation for releases and `main` are available here:
 
 ## Installation
 
-You can add SharingGRDB to an Xcode project by adding it to your project as a package.
+You can add SharingGRDB to an Xcode project by adding it to your project as a package…
 
 > https://github.com/pointfreeco/sharing-grdb
 
-And adding the `SharingGRDB` product to your target.
+…and adding the `SharingGRDB` product to your target.
 
 > [!TIP]
 > SharingGRDB's primary product is the `SharingGRDB` module, which includes all of the library's

--- a/Sources/SharingGRDB/Documentation.docc/SharingGRDB.md
+++ b/Sources/SharingGRDB/Documentation.docc/SharingGRDB.md
@@ -18,5 +18,26 @@ See [`SharingGRDBCore`](sharinggrdbcore) for documentation on the integration wi
 See [`StructuredQueriesGRDBCore`](sharinggrdbcore) for documentation on the integration between
 [StructuredQueries][] and [GRDB][].
 
+> Tip: SharingGRDB's primary product is the `SharingGRDB` module, which includes all of the
+> library's functionality, including the `@Fetch` family of property wrappers, the `@Table` macro,
+> and tools for driving StructuredQueries using GRDB. This is the module that most library users
+> should depend on.
+>
+> If you are a library author that wishes to extend SharingGRDB with additional functionality, you
+> may want to depend on a different module:
+>
+>   * [`SharingGRDBCore`](sharinggrdbcore): This product includes everything in `SharingGRDB`
+>     _except_ the macros (`@Table`, `#sql`, _etc._). This module can be imported to extend
+>     SharingGRDB with additional functionality without forcing the heavyweight dependency of
+>     SwiftSyntax on your users.
+>   * `StructuredQueriesGRDB`: This product includes everything in `SharingGRDB` _except_ the
+>     `@Fetch` family of property wrappers. It can be imported if you want to extend
+>     StructuredQueries' GRDB driver but do not need access to observation tools provided by
+>     Sharing.
+>   * [`StructuredQueriesGRDBCore`](sharinggrdbcore): This product includes everything in
+>     `StructuredQueriesGRDB` _except_ the macros. This module can be imported to extend
+>     StructuredQueries' GRDB driver with additional functionality without forcing the heavyweight
+>     dependency of SwiftSyntax on your users.
+
 [GRDB]: https://github.com/groue/GRDB.swift
 [StructuredQueries]: https://github.com/pointfreeco/swift-structured-queries


### PR DESCRIPTION
We should point out to users that they should generally depend on the `SharingGRDB` module and not worry about the others.