### PR TITLE
Add projected setter to `@Fetch` wrappers

### DIFF
--- a/Sources/SharingGRDBCore/Fetch.swift
+++ b/Sources/SharingGRDBCore/Fetch.swift
@@ -33,7 +33,8 @@ public struct Fetch<Value: Sendable>: Sendable {
   /// Useful if you want to access various property wrapper state, like ``loadError``,
   /// ``isLoading``, and ``publisher``.
   public var projectedValue: Self {
-    self
+    get { self }
+    nonmutating set { sharedReader.projectedValue = newValue.sharedReader.projectedValue }
   }
 
   /// Returns a ``sharedReader`` for the given key path.

--- a/Sources/SharingGRDBCore/FetchAll.swift
+++ b/Sources/SharingGRDBCore/FetchAll.swift
@@ -33,7 +33,8 @@ public struct FetchAll<Element: Sendable>: Sendable {
   /// Useful if you want to access various property wrapper state, like ``loadError``,
   /// ``isLoading``, and ``publisher``.
   public var projectedValue: Self {
-    self
+    get { self }
+    nonmutating set { sharedReader.projectedValue = newValue.sharedReader.projectedValue }
   }
 
   /// Returns a ``sharedReader`` for the given key path.

--- a/Sources/SharingGRDBCore/FetchOne.swift
+++ b/Sources/SharingGRDBCore/FetchOne.swift
@@ -33,7 +33,8 @@ public struct FetchOne<Value: Sendable>: Sendable {
   /// Useful if you want to access various property wrapper state, like ``loadError``,
   /// ``isLoading``, and ``publisher``.
   public var projectedValue: Self {
-    self
+    get { self }
+    nonmutating set { sharedReader.projectedValue = newValue.sharedReader.projectedValue }
   }
 
   /// Returns a ``sharedReader`` for the given key path.


### PR DESCRIPTION
While `load` is the primary API for reloading a key, we should promote this synchronous API, as well.