### PR TITLE
`@FetchOne` improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         swift:
-          - '6.0'
+          - '6.1'
     runs-on: ubuntu-latest
     container: swift:${{ matrix.swift }}
     steps:

--- a/Sources/SharingGRDBCore/FetchAll.swift
+++ b/Sources/SharingGRDBCore/FetchAll.swift
@@ -120,33 +120,6 @@ public struct FetchAll<Element: Sendable>: Sendable {
   ///   - statement: A query associated with the wrapped value.
   ///   - database: The database to read from. A value of `nil` will use the default database
   ///     (`@Dependency(\.defaultDatabase)`).
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
-    wrappedValue: [Element] = [],
-    _ statement: S,
-    database: (any DatabaseReader)? = nil
-  )
-  where
-    Element == (S.From.QueryOutput, repeat (each J).QueryOutput),
-    S.QueryValue == (),
-    S.From.QueryOutput: Sendable,
-    S.Joins == (repeat each J),
-    repeat (each J).QueryOutput: Sendable
-  {
-    let statement = statement.selectStar().asSelect()
-    sharedReader = SharedReader(
-      wrappedValue: wrappedValue,
-      .fetch(FetchAllStatementPackRequest(statement: statement), database: database)
-    )
-  }
-
-  /// Initializes this property with a query associated with the wrapped value.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
   public init<V: QueryRepresentable>(
     wrappedValue: [Element] = [],
     _ statement: some StructuredQueriesCore.Statement<V>,
@@ -189,33 +162,6 @@ public struct FetchAll<Element: Sendable>: Sendable {
     )
   }
 
-  /// Initializes this property with a query associated with the wrapped value.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
-    wrappedValue: [Element] = [],
-    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
-    database: (any DatabaseReader)? = nil
-  )
-  where
-    Element == (V1.QueryOutput, repeat (each V2).QueryOutput),
-    V1.QueryOutput: Sendable,
-    repeat (each V2).QueryOutput: Sendable
-  {
-    sharedReader = SharedReader(
-      wrappedValue: wrappedValue,
-      .fetch(
-        FetchAllStatementPackRequest(statement: statement),
-        database: database
-      )
-    )
-  }
-
   /// Replaces the wrapped value with data from the given query.
   ///
   /// - Parameters:
@@ -247,34 +193,6 @@ public struct FetchAll<Element: Sendable>: Sendable {
   ///   - statement: A query associated with the wrapped value.
   ///   - database: The database to read from. A value of `nil` will use the default database
   ///     (`@Dependency(\.defaultDatabase)`).
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public func load<S: SelectStatement, each J: StructuredQueriesCore.Table>(
-    _ statement: S,
-    database: (any DatabaseReader)? = nil
-  ) async throws
-  where
-    Element == (S.From.QueryOutput, repeat (each J).QueryOutput),
-    S.QueryValue == (),
-    S.From.QueryOutput: Sendable,
-    S.Joins == (repeat each J),
-    repeat (each J).QueryOutput: Sendable
-  {
-    let statement = statement.selectStar().asSelect()
-    try await sharedReader.load(
-      .fetch(
-        FetchAllStatementPackRequest(statement: statement),
-        database: database
-      )
-    )
-  }
-
-  /// Replaces the wrapped value with data from the given query.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
   public func load<V: QueryRepresentable>(
     _ statement: some StructuredQueriesCore.Statement<V>,
     database: (any DatabaseReader)? = nil
@@ -286,31 +204,6 @@ public struct FetchAll<Element: Sendable>: Sendable {
     try await sharedReader.load(
       .fetch(
         FetchAllStatementValueRequest(statement: statement),
-        database: database
-      )
-    )
-  }
-
-  /// Replaces the wrapped value with data from the given query.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public func load<V1: QueryRepresentable, each V2: QueryRepresentable>(
-    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
-    database: (any DatabaseReader)? = nil
-  ) async throws
-  where
-    Element == (V1.QueryOutput, repeat (each V2).QueryOutput),
-    V1.QueryOutput: Sendable,
-    repeat (each V2).QueryOutput: Sendable
-  {
-    try await sharedReader.load(
-      .fetch(
-        FetchAllStatementPackRequest(statement: statement),
         database: database
       )
     )
@@ -374,40 +267,6 @@ extension FetchAll {
   ///     (`@Dependency(\.defaultDatabase)`).
   ///   - scheduler: The scheduler to observe from. By default, database observation is performed
   ///     asynchronously on the main queue.
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
-    wrappedValue: [Element] = [],
-    _ statement: S,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  )
-  where
-    Element == (S.From.QueryOutput, repeat (each J).QueryOutput),
-    S.QueryValue == (),
-    S.From.QueryOutput: Sendable,
-    S.Joins == (repeat each J),
-    repeat (each J).QueryOutput: Sendable
-  {
-    let statement = statement.selectStar().asSelect()
-    sharedReader = SharedReader(
-      wrappedValue: wrappedValue,
-      .fetch(
-        FetchAllStatementPackRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
-      )
-    )
-  }
-
-  /// Initializes this property with a query associated with the wrapped value.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
-  ///     asynchronously on the main queue.
   public init<V: QueryRepresentable>(
     wrappedValue: [Element] = [],
     _ statement: some StructuredQueriesCore.Statement<V>,
@@ -443,44 +302,13 @@ extension FetchAll {
     scheduler: some ValueObservationScheduler & Hashable
   )
   where
-  Element: QueryRepresentable,
-  Element == S.QueryValue.QueryOutput
+    Element: QueryRepresentable,
+    Element == S.QueryValue.QueryOutput
   {
     sharedReader = SharedReader(
       wrappedValue: wrappedValue,
       .fetch(
         FetchAllStatementValueRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
-      )
-    )
-  }
-
-  /// Initializes this property with a query associated with the wrapped value.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
-  ///     asynchronously on the main queue.
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
-    wrappedValue: [Element] = [],
-    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  )
-  where
-    Element == (V1.QueryOutput, repeat (each V2).QueryOutput),
-    V1.QueryOutput: Sendable,
-    repeat (each V2).QueryOutput: Sendable
-  {
-    sharedReader = SharedReader(
-      wrappedValue: wrappedValue,
-      .fetch(
-        FetchAllStatementPackRequest(statement: statement),
         database: database,
         scheduler: scheduler
       )
@@ -524,38 +352,6 @@ extension FetchAll {
   ///     (`@Dependency(\.defaultDatabase)`).
   ///   - scheduler: The scheduler to observe from. By default, database observation is performed
   ///     asynchronously on the main queue.
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public func load<S: SelectStatement, each J: StructuredQueriesCore.Table>(
-    _ statement: S,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  ) async throws
-  where
-    Element == (S.From.QueryOutput, repeat (each J).QueryOutput),
-    S.QueryValue == (),
-    S.From.QueryOutput: Sendable,
-    S.Joins == (repeat each J),
-    repeat (each J).QueryOutput: Sendable
-  {
-    let statement = statement.selectStar().asSelect()
-    try await sharedReader.load(
-      .fetch(
-        FetchAllStatementPackRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
-      )
-    )
-  }
-
-  /// Replaces the wrapped value with data from the given query.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
-  ///     asynchronously on the main queue.
   public func load<V: QueryRepresentable>(
     _ statement: some StructuredQueriesCore.Statement<V>,
     database: (any DatabaseReader)? = nil,
@@ -570,34 +366,6 @@ extension FetchAll {
         FetchAllStatementValueRequest(statement: statement),
         database: database,
         scheduler: scheduler
-      )
-    )
-  }
-
-  /// Replaces the wrapped value with data from the given query.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
-  ///     asynchronously on the main queue.
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public func load<V1: QueryRepresentable, each V2: QueryRepresentable>(
-    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  ) async throws
-  where
-    Element == (V1.QueryOutput, repeat (each V2).QueryOutput),
-    V1.QueryOutput: Sendable,
-    repeat (each V2).QueryOutput: Sendable
-  {
-    try await sharedReader.load(
-      .fetch(
-        FetchAllStatementPackRequest(statement: statement),
-        database: database
       )
     )
   }
@@ -671,40 +439,6 @@ extension FetchAll: Equatable where Element: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
-    @_disfavoredOverload
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
-      wrappedValue: [Element] = [],
-      _ statement: S,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation
-    )
-    where
-      Element == (S.From.QueryOutput, repeat (each J).QueryOutput),
-      S.QueryValue == (),
-      S.From.QueryOutput: Sendable,
-      S.Joins == (repeat each J),
-      repeat (each J).QueryOutput: Sendable
-    {
-      let statement = statement.selectStar().asSelect()
-      sharedReader = SharedReader(
-        wrappedValue: wrappedValue,
-        .fetch(
-          FetchAllStatementPackRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
-      )
-    }
-
-    /// Initializes this property with a query associated with the wrapped value.
-    ///
-    /// - Parameters:
-    ///   - statement: A query associated with the wrapped value.
-    ///   - database: The database to read from. A value of `nil` will use the default database
-    ///     (`@Dependency(\.defaultDatabase)`).
-    ///   - animation: The animation to use for user interface changes that result from changes to
-    ///     the fetched results.
     public init<V: QueryRepresentable>(
       wrappedValue: [Element] = [],
       _ statement: some StructuredQueriesCore.Statement<V>,
@@ -740,44 +474,13 @@ extension FetchAll: Equatable where Element: Equatable {
       animation: Animation
     )
     where
-    Element: QueryRepresentable,
-    Element == S.QueryValue.QueryOutput
+      Element: QueryRepresentable,
+      Element == S.QueryValue.QueryOutput
     {
       sharedReader = SharedReader(
         wrappedValue: wrappedValue,
         .fetch(
           FetchAllStatementValueRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
-      )
-    }
-
-    /// Initializes this property with a query associated with the wrapped value.
-    ///
-    /// - Parameters:
-    ///   - statement: A query associated with the wrapped value.
-    ///   - database: The database to read from. A value of `nil` will use the default database
-    ///     (`@Dependency(\.defaultDatabase)`).
-    ///   - animation: The animation to use for user interface changes that result from changes to
-    ///     the fetched results.
-    @_disfavoredOverload
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
-      wrappedValue: [Element] = [],
-      _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation
-    )
-    where
-      Element == (V1.QueryOutput, repeat (each V2).QueryOutput),
-      V1.QueryOutput: Sendable,
-      repeat (each V2).QueryOutput: Sendable
-    {
-      sharedReader = SharedReader(
-        wrappedValue: wrappedValue,
-        .fetch(
-          FetchAllStatementPackRequest(statement: statement),
           database: database,
           animation: animation
         )
@@ -821,38 +524,6 @@ extension FetchAll: Equatable where Element: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
-    @_disfavoredOverload
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    public func load<S: SelectStatement, each J: StructuredQueriesCore.Table>(
-      _ statement: S,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation
-    ) async throws
-    where
-      Element == (S.From.QueryOutput, repeat (each J).QueryOutput),
-      S.QueryValue == (),
-      S.From.QueryOutput: Sendable,
-      S.Joins == (repeat each J),
-      repeat (each J).QueryOutput: Sendable
-    {
-      let statement = statement.selectStar().asSelect()
-      try await sharedReader.load(
-        .fetch(
-          FetchAllStatementPackRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
-      )
-    }
-
-    /// Replaces the wrapped value with data from the given query.
-    ///
-    /// - Parameters:
-    ///   - statement: A query associated with the wrapped value.
-    ///   - database: The database to read from. A value of `nil` will use the default database
-    ///     (`@Dependency(\.defaultDatabase)`).
-    ///   - animation: The animation to use for user interface changes that result from changes to
-    ///     the fetched results.
     public func load<V: QueryRepresentable>(
       _ statement: some StructuredQueriesCore.Statement<V>,
       database: (any DatabaseReader)? = nil,
@@ -870,49 +541,12 @@ extension FetchAll: Equatable where Element: Equatable {
         )
       )
     }
-
-    /// Replaces the wrapped value with data from the given query.
-    ///
-    /// - Parameters:
-    ///   - statement: A query associated with the wrapped value.
-    ///   - database: The database to read from. A value of `nil` will use the default database
-    ///     (`@Dependency(\.defaultDatabase)`).
-    ///   - animation: The animation to use for user interface changes that result from changes to
-    ///     the fetched results.
-    @_disfavoredOverload
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    public func load<V1: QueryRepresentable, each V2: QueryRepresentable>(
-      _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation
-    ) async throws
-    where
-      Element == (V1.QueryOutput, repeat (each V2).QueryOutput),
-      V1.QueryOutput: Sendable,
-      repeat (each V2).QueryOutput: Sendable
-    {
-      try await sharedReader.load(
-        .fetch(
-          FetchAllStatementPackRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
-      )
-    }
   }
 #endif
 
 private struct FetchAllStatementValueRequest<Value: QueryRepresentable>: StatementKeyRequest {
   let statement: any StructuredQueriesCore.Statement<Value>
   func fetch(_ db: Database) throws -> [Value.QueryOutput] {
-    try statement.fetchAll(db)
-  }
-}
-
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-private struct FetchAllStatementPackRequest<each Value: QueryRepresentable>: StatementKeyRequest {
-  let statement: any StructuredQueriesCore.Statement<(repeat each Value)>
-  func fetch(_ db: Database) throws -> [(repeat (each Value).QueryOutput)] {
     try statement.fetchAll(db)
   }
 }

--- a/Sources/SharingGRDBCore/FetchAll.swift
+++ b/Sources/SharingGRDBCore/FetchAll.swift
@@ -104,14 +104,8 @@ public struct FetchAll<Element: Sendable>: Sendable {
     S.From.QueryOutput: Sendable,
     S.Joins == ()
   {
-    let statement = statement.selectStar().asSelect()
-    sharedReader = SharedReader(
-      wrappedValue: wrappedValue,
-      .fetch(
-        FetchAllStatementValueRequest(statement: statement),
-        database: database
-      )
-    )
+    let statement = statement.selectStar()
+    self.init(wrappedValue: wrappedValue, statement, database: database)
   }
 
   /// Initializes this property with a query associated with the wrapped value.
@@ -178,13 +172,8 @@ public struct FetchAll<Element: Sendable>: Sendable {
     S.From.QueryOutput: Sendable,
     S.Joins == ()
   {
-    let statement = statement.selectStar().asSelect()
-    try await sharedReader.load(
-      .fetch(
-        FetchAllStatementValueRequest(statement: statement),
-        database: database
-      )
-    )
+    let statement = statement.selectStar()
+    try await load(statement, database: database)
   }
 
   /// Replaces the wrapped value with data from the given query.
@@ -248,15 +237,8 @@ extension FetchAll {
     S.From.QueryOutput: Sendable,
     S.Joins == ()
   {
-    let statement = statement.selectStar().asSelect()
-    sharedReader = SharedReader(
-      wrappedValue: wrappedValue,
-      .fetch(
-        FetchAllStatementValueRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
-      )
-    )
+    let statement = statement.selectStar()
+    self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
   }
 
   /// Initializes this property with a query associated with the wrapped value.
@@ -334,14 +316,8 @@ extension FetchAll {
     S.From.QueryOutput: Sendable,
     S.Joins == ()
   {
-    let statement = statement.selectStar().asSelect()
-    try await sharedReader.load(
-      .fetch(
-        FetchAllStatementValueRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
-      )
-    )
+    let statement = statement.selectStar()
+    try await load(statement, database: database, scheduler: scheduler)
   }
 
   /// Replaces the wrapped value with data from the given query.
@@ -396,8 +372,7 @@ extension FetchAll: Equatable where Element: Equatable {
       animation: Animation
     )
     where Element: StructuredQueriesCore.Table, Element.QueryOutput == Element {
-      let statement = Element.all.selectStar().asSelect()
-      self.init(wrappedValue: wrappedValue, statement, database: database, animation: animation)
+      self.init(wrappedValue: wrappedValue, database: database, scheduler: .animation(animation))
     }
 
     /// Initializes this property with a query associated with the wrapped value.
@@ -420,14 +395,11 @@ extension FetchAll: Equatable where Element: Equatable {
       S.From.QueryOutput: Sendable,
       S.Joins == ()
     {
-      let statement = statement.selectStar().asSelect()
-      sharedReader = SharedReader(
+      self.init(
         wrappedValue: wrappedValue,
-        .fetch(
-          FetchAllStatementValueRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
+        statement,
+        database: database,
+        scheduler: .animation(animation)
       )
     }
 
@@ -449,13 +421,11 @@ extension FetchAll: Equatable where Element: Equatable {
       Element == V.QueryOutput,
       V.QueryOutput: Sendable
     {
-      sharedReader = SharedReader(
+      self.init(
         wrappedValue: wrappedValue,
-        .fetch(
-          FetchAllStatementValueRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
+        statement,
+        database: database,
+        scheduler: .animation(animation)
       )
     }
 
@@ -477,13 +447,11 @@ extension FetchAll: Equatable where Element: Equatable {
       Element: QueryRepresentable,
       Element == S.QueryValue.QueryOutput
     {
-      sharedReader = SharedReader(
+      self.init(
         wrappedValue: wrappedValue,
-        .fetch(
-          FetchAllStatementValueRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
+        statement,
+        database: database,
+        scheduler: .animation(animation)
       )
     }
 
@@ -506,14 +474,8 @@ extension FetchAll: Equatable where Element: Equatable {
       S.From.QueryOutput: Sendable,
       S.Joins == ()
     {
-      let statement = statement.selectStar().asSelect()
-      try await sharedReader.load(
-        .fetch(
-          FetchAllStatementValueRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
-      )
+      let statement = statement.selectStar()
+      try await load(statement, database: database, animation: animation)
     }
 
     /// Replaces the wrapped value with data from the given query.

--- a/Sources/SharingGRDBCore/FetchKey+SwiftUI.swift
+++ b/Sources/SharingGRDBCore/FetchKey+SwiftUI.swift
@@ -111,10 +111,10 @@
     }
   }
 
-  private struct AnimatedScheduler: ValueObservationScheduler, Hashable {
+  package struct AnimatedScheduler: ValueObservationScheduler, Hashable {
     let animation: Animation
-    func immediateInitialValue() -> Bool { true }
-    func schedule(_ action: @escaping @Sendable () -> Void) {
+    package func immediateInitialValue() -> Bool { true }
+    package func schedule(_ action: @escaping @Sendable () -> Void) {
       DispatchQueue.main.async {
         withAnimation(animation) {
           action()
@@ -124,7 +124,7 @@
   }
 
   extension ValueObservationScheduler where Self == AnimatedScheduler {
-    fileprivate static func animation(_ animation: Animation) -> Self {
+    package static func animation(_ animation: Animation) -> Self {
       AnimatedScheduler(animation: animation)
     }
   }

--- a/Sources/SharingGRDBCore/FetchOne.swift
+++ b/Sources/SharingGRDBCore/FetchOne.swift
@@ -107,14 +107,8 @@ public struct FetchOne<Value: Sendable>: Sendable {
     S.QueryValue == (),
     S.Joins == ()
   {
-    let statement = statement.selectStar().asSelect()
-    sharedReader = SharedReader(
-      wrappedValue: wrappedValue,
-      .fetch(
-        FetchOneStatementValueRequest(statement: statement),
-        database: database
-      )
-    )
+    let statement = statement.selectStar()
+    self.init(wrappedValue: wrappedValue, statement, database: database)
   }
 
   /// Initializes this property with a query associated with the wrapped value.
@@ -181,13 +175,8 @@ public struct FetchOne<Value: Sendable>: Sendable {
     S.QueryValue == (),
     S.Joins == ()
   {
-    let statement = statement.selectStar().asSelect()
-    try await sharedReader.load(
-      .fetch(
-        FetchOneStatementValueRequest(statement: statement),
-        database: database
-      )
-    )
+    let statement = statement.selectStar()
+    try await load(statement, database: database)
   }
 
   /// Replaces the wrapped value with data from the given query.
@@ -233,15 +222,8 @@ extension FetchOne {
     S.QueryValue == (),
     S.Joins == ()
   {
-    let statement = statement.selectStar().asSelect()
-    sharedReader = SharedReader(
-      wrappedValue: wrappedValue,
-      .fetch(
-        FetchOneStatementValueRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
-      )
-    )
+    let statement = statement.selectStar()
+    self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
   }
 
   /// Initializes this property with a query associated with the wrapped value.
@@ -319,14 +301,8 @@ extension FetchOne {
     S.QueryValue == (),
     S.Joins == ()
   {
-    let statement = statement.selectStar().asSelect()
-    try await sharedReader.load(
-      .fetch(
-        FetchOneStatementValueRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
-      )
-    )
+    let statement = statement.selectStar()
+    try await load(statement, database: database, scheduler: scheduler)
   }
 
   /// Replaces the wrapped value with data from the given query.
@@ -387,14 +363,11 @@ extension FetchOne: Equatable where Value: Equatable {
       S.QueryValue == (),
       S.Joins == ()
     {
-      let statement = statement.selectStar().asSelect()
-      sharedReader = SharedReader(
+      self.init(
         wrappedValue: wrappedValue,
-        .fetch(
-          FetchOneStatementValueRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
+        statement,
+        database: database,
+        scheduler: .animation(animation)
       )
     }
 
@@ -416,13 +389,11 @@ extension FetchOne: Equatable where Value: Equatable {
     where
       Value == V.QueryOutput
     {
-      sharedReader = SharedReader(
+      self.init(
         wrappedValue: wrappedValue,
-        .fetch(
-          FetchOneStatementValueRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
+        statement,
+        database: database,
+        scheduler: .animation(animation)
       )
     }
 
@@ -445,13 +416,11 @@ extension FetchOne: Equatable where Value: Equatable {
       Value: QueryRepresentable,
       Value == S.QueryValue.QueryOutput
     {
-      sharedReader = SharedReader(
+      self.init(
         wrappedValue: wrappedValue,
-        .fetch(
-          FetchOneStatementValueRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
+        statement,
+        database: database,
+        scheduler: .animation(animation)
       )
     }
 
@@ -473,14 +442,7 @@ extension FetchOne: Equatable where Value: Equatable {
       S.QueryValue == (),
       S.Joins == ()
     {
-      let statement = statement.selectStar().asSelect()
-      try await sharedReader.load(
-        .fetch(
-          FetchOneStatementValueRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
-      )
+      try await load(statement, database: database, scheduler: .animation(animation))
     }
 
     /// Replaces the wrapped value with data from the given query.
@@ -499,13 +461,7 @@ extension FetchOne: Equatable where Value: Equatable {
     where
       Value == V.QueryOutput
     {
-      try await sharedReader.load(
-        .fetch(
-          FetchOneStatementValueRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
-      )
+      try await load(statement, database: database, scheduler: .animation(animation))
     }
   }
 #endif

--- a/Sources/SharingGRDBCore/FetchOne.swift
+++ b/Sources/SharingGRDBCore/FetchOne.swift
@@ -124,35 +124,6 @@ public struct FetchOne<Value: Sendable>: Sendable {
   ///   - statement: A query associated with the wrapped value.
   ///   - database: The database to read from. A value of `nil` will use the default database
   ///     (`@Dependency(\.defaultDatabase)`).
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
-    wrappedValue: (S.From.QueryOutput, repeat (each J).QueryOutput),
-    _ statement: S,
-    database: (any DatabaseReader)? = nil
-  )
-  where
-    Value == (S.From.QueryOutput, repeat (each J).QueryOutput),
-    S.QueryValue == (),
-    S.Joins == (repeat each J)
-  {
-    let statement = statement.selectStar().asSelect()
-    sharedReader = SharedReader(
-      wrappedValue: wrappedValue,
-      .fetch(
-        FetchOneStatementPackRequest(statement: statement),
-        database: database
-      )
-    )
-  }
-
-  /// Initializes this property with a query associated with the wrapped value.
-  ///
-  /// - Parameters:
-  ///   - wrappedValue: A default value to associate with this property.
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
   public init<V: QueryRepresentable>(
     wrappedValue: V.QueryOutput,
     _ statement: some StructuredQueriesCore.Statement<V>,
@@ -183,39 +154,13 @@ public struct FetchOne<Value: Sendable>: Sendable {
     database: (any DatabaseReader)? = nil
   )
   where
-  Value: QueryRepresentable,
-  Value == S.QueryValue.QueryOutput
+    Value: QueryRepresentable,
+    Value == S.QueryValue.QueryOutput
   {
     sharedReader = SharedReader(
       wrappedValue: wrappedValue,
       .fetch(
         FetchOneStatementValueRequest(statement: statement),
-        database: database
-      )
-    )
-  }
-
-  /// Initializes this property with a query associated with the wrapped value.
-  ///
-  /// - Parameters:
-  ///   - wrappedValue: A default value to associate with this property.
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
-    wrappedValue: (V1.QueryOutput, repeat (each V2).QueryOutput),
-    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
-    database: (any DatabaseReader)? = nil
-  )
-  where
-    Value == (V1.QueryOutput, repeat (each V2).QueryOutput)
-  {
-    sharedReader = SharedReader(
-      wrappedValue: wrappedValue,
-      .fetch(
-        FetchOneStatementPackRequest(statement: statement),
         database: database
       )
     )
@@ -251,32 +196,6 @@ public struct FetchOne<Value: Sendable>: Sendable {
   ///   - statement: A query associated with the wrapped value.
   ///   - database: The database to read from. A value of `nil` will use the default database
   ///     (`@Dependency(\.defaultDatabase)`).
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public func load<S: SelectStatement, each J: StructuredQueriesCore.Table>(
-    _ statement: S,
-    database: (any DatabaseReader)? = nil
-  ) async throws
-  where
-    Value == (S.From.QueryOutput, repeat (each J).QueryOutput),
-    S.QueryValue == (),
-    S.Joins == (repeat each J)
-  {
-    let statement = statement.selectStar().asSelect()
-    try await sharedReader.load(
-      .fetch(
-        FetchOneStatementPackRequest(statement: statement),
-        database: database
-      )
-    )
-  }
-
-  /// Replaces the wrapped value with data from the given query.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
   public func load<V: QueryRepresentable>(
     _ statement: some StructuredQueriesCore.Statement<V>,
     database: (any DatabaseReader)? = nil
@@ -287,29 +206,6 @@ public struct FetchOne<Value: Sendable>: Sendable {
     try await sharedReader.load(
       .fetch(
         FetchOneStatementValueRequest(statement: statement),
-        database: database
-      )
-    )
-  }
-
-  /// Replaces the wrapped value with data from the given query.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public func load<V1: QueryRepresentable, each V2: QueryRepresentable>(
-    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
-    database: (any DatabaseReader)? = nil
-  ) async throws
-  where
-    Value == (V1.QueryOutput, repeat (each V2).QueryOutput)
-  {
-    try await sharedReader.load(
-      .fetch(
-        FetchOneStatementPackRequest(statement: statement),
         database: database
       )
     )
@@ -357,39 +253,6 @@ extension FetchOne {
   ///     (`@Dependency(\.defaultDatabase)`).
   ///   - scheduler: The scheduler to observe from. By default, database observation is performed
   ///     asynchronously on the main queue.
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
-    wrappedValue: (S.From.QueryOutput, repeat (each J).QueryOutput),
-    _ statement: S,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  )
-  where
-    Value == (S.From.QueryOutput, repeat (each J).QueryOutput),
-    S.QueryValue == (),
-    S.Joins == (repeat each J)
-  {
-    let statement = statement.selectStar().asSelect()
-    sharedReader = SharedReader(
-      wrappedValue: wrappedValue,
-      .fetch(
-        FetchOneStatementPackRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
-      )
-    )
-  }
-
-  /// Initializes this property with a query associated with the wrapped value.
-  ///
-  /// - Parameters:
-  ///   - wrappedValue: A default value to associate with this property.
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
-  ///     asynchronously on the main queue.
   public init<V: QueryRepresentable>(
     wrappedValue: V.QueryOutput,
     _ statement: some StructuredQueriesCore.Statement<V>,
@@ -425,43 +288,13 @@ extension FetchOne {
     scheduler: some ValueObservationScheduler & Hashable
   )
   where
-  Value: QueryRepresentable,
-  Value == S.QueryValue.QueryOutput
+    Value: QueryRepresentable,
+    Value == S.QueryValue.QueryOutput
   {
     sharedReader = SharedReader(
       wrappedValue: wrappedValue,
       .fetch(
         FetchOneStatementValueRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
-      )
-    )
-  }
-
-  /// Initializes this property with a query associated with the wrapped value.
-  ///
-  /// - Parameters:
-  ///   - wrappedValue: A default value to associate with this property.
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
-  ///     asynchronously on the main queue.
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
-    wrappedValue: (V1.QueryOutput, repeat (each V2).QueryOutput),
-    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  )
-  where
-    Value == (V1.QueryOutput, repeat (each V2).QueryOutput)
-  {
-    sharedReader = SharedReader(
-      wrappedValue: wrappedValue,
-      .fetch(
-        FetchOneStatementPackRequest(statement: statement),
         database: database,
         scheduler: scheduler
       )
@@ -504,36 +337,6 @@ extension FetchOne {
   ///     (`@Dependency(\.defaultDatabase)`).
   ///   - scheduler: The scheduler to observe from. By default, database observation is performed
   ///     asynchronously on the main queue.
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public func load<S: SelectStatement, each J: StructuredQueriesCore.Table>(
-    _ statement: S,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  ) async throws
-  where
-    Value == (S.From.QueryOutput, repeat (each J).QueryOutput),
-    S.QueryValue == (),
-    S.Joins == (repeat each J)
-  {
-    let statement = statement.selectStar().asSelect()
-    try await sharedReader.load(
-      .fetch(
-        FetchOneStatementPackRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
-      )
-    )
-  }
-
-  /// Replaces the wrapped value with data from the given query.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
-  ///     asynchronously on the main queue.
   public func load<V: QueryRepresentable>(
     _ statement: some StructuredQueriesCore.Statement<V>,
     database: (any DatabaseReader)? = nil,
@@ -545,33 +348,6 @@ extension FetchOne {
     try await sharedReader.load(
       .fetch(
         FetchOneStatementValueRequest(statement: statement),
-        database: database,
-        scheduler: scheduler
-      )
-    )
-  }
-
-  /// Replaces the wrapped value with data from the given query.
-  ///
-  /// - Parameters:
-  ///   - statement: A query associated with the wrapped value.
-  ///   - database: The database to read from. A value of `nil` will use the default database
-  ///     (`@Dependency(\.defaultDatabase)`).
-  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
-  ///     asynchronously on the main queue.
-  @_disfavoredOverload
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  public func load<V1: QueryRepresentable, each V2: QueryRepresentable>(
-    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
-    database: (any DatabaseReader)? = nil,
-    scheduler: some ValueObservationScheduler & Hashable
-  ) async throws
-  where
-    Value == (V1.QueryOutput, repeat (each V2).QueryOutput)
-  {
-    try await sharedReader.load(
-      .fetch(
-        FetchOneStatementPackRequest(statement: statement),
         database: database,
         scheduler: scheduler
       )
@@ -631,39 +407,6 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
-    @_disfavoredOverload
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
-      wrappedValue: (S.From.QueryOutput, repeat (each J).QueryOutput),
-      _ statement: S,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation
-    )
-    where
-      Value == (S.From.QueryOutput, repeat (each J).QueryOutput),
-      S.QueryValue == (),
-      S.Joins == (repeat each J)
-    {
-      let statement = statement.selectStar().asSelect()
-      sharedReader = SharedReader(
-        wrappedValue: wrappedValue,
-        .fetch(
-          FetchOneStatementPackRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
-      )
-    }
-
-    /// Initializes this property with a query associated with the wrapped value.
-    ///
-    /// - Parameters:
-    ///   - wrappedValue: A default value to associate with this property.
-    ///   - statement: A query associated with the wrapped value.
-    ///   - database: The database to read from. A value of `nil` will use the default database
-    ///     (`@Dependency(\.defaultDatabase)`).
-    ///   - animation: The animation to use for user interface changes that result from changes to
-    ///     the fetched results.
     public init<V: QueryRepresentable>(
       wrappedValue: V.QueryOutput,
       _ statement: some StructuredQueriesCore.Statement<V>,
@@ -699,43 +442,13 @@ extension FetchOne: Equatable where Value: Equatable {
       animation: Animation
     )
     where
-    Value: QueryRepresentable,
-    Value == S.QueryValue.QueryOutput
+      Value: QueryRepresentable,
+      Value == S.QueryValue.QueryOutput
     {
       sharedReader = SharedReader(
         wrappedValue: wrappedValue,
         .fetch(
           FetchOneStatementValueRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
-      )
-    }
-
-    /// Initializes this property with a query associated with the wrapped value.
-    ///
-    /// - Parameters:
-    ///   - wrappedValue: A default value to associate with this property.
-    ///   - statement: A query associated with the wrapped value.
-    ///   - database: The database to read from. A value of `nil` will use the default database
-    ///     (`@Dependency(\.defaultDatabase)`).
-    ///   - animation: The animation to use for user interface changes that result from changes to
-    ///     the fetched results.
-    @_disfavoredOverload
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
-      wrappedValue: (V1.QueryOutput, repeat (each V2).QueryOutput),
-      _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation
-    )
-    where
-      Value == (V1.QueryOutput, repeat (each V2).QueryOutput)
-    {
-      sharedReader = SharedReader(
-        wrappedValue: wrappedValue,
-        .fetch(
-          FetchOneStatementPackRequest(statement: statement),
           database: database,
           animation: animation
         )
@@ -778,36 +491,6 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
-    @_disfavoredOverload
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    public func load<S: SelectStatement, each J: StructuredQueriesCore.Table>(
-      _ statement: S,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation
-    ) async throws
-    where
-      Value == (S.From.QueryOutput, repeat (each J).QueryOutput),
-      S.QueryValue == (),
-      S.Joins == (repeat each J)
-    {
-      let statement = statement.selectStar().asSelect()
-      try await sharedReader.load(
-        .fetch(
-          FetchOneStatementPackRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
-      )
-    }
-
-    /// Replaces the wrapped value with data from the given query.
-    ///
-    /// - Parameters:
-    ///   - statement: A query associated with the wrapped value.
-    ///   - database: The database to read from. A value of `nil` will use the default database
-    ///     (`@Dependency(\.defaultDatabase)`).
-    ///   - animation: The animation to use for user interface changes that result from changes to
-    ///     the fetched results.
     public func load<V: QueryRepresentable>(
       _ statement: some StructuredQueriesCore.Statement<V>,
       database: (any DatabaseReader)? = nil,
@@ -824,49 +507,12 @@ extension FetchOne: Equatable where Value: Equatable {
         )
       )
     }
-
-    /// Replaces the wrapped value with data from the given query.
-    ///
-    /// - Parameters:
-    ///   - statement: A query associated with the wrapped value.
-    ///   - database: The database to read from. A value of `nil` will use the default database
-    ///     (`@Dependency(\.defaultDatabase)`).
-    ///   - animation: The animation to use for user interface changes that result from changes to
-    ///     the fetched results.
-    @_disfavoredOverload
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    public func load<V1: QueryRepresentable, each V2: QueryRepresentable>(
-      _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
-      database: (any DatabaseReader)? = nil,
-      animation: Animation
-    ) async throws
-    where
-      Value == (V1.QueryOutput, repeat (each V2).QueryOutput)
-    {
-      try await sharedReader.load(
-        .fetch(
-          FetchOneStatementPackRequest(statement: statement),
-          database: database,
-          animation: animation
-        )
-      )
-    }
   }
 #endif
 
 private struct FetchOneStatementValueRequest<Value: QueryRepresentable>: StatementKeyRequest {
   let statement: any StructuredQueriesCore.Statement<Value>
   func fetch(_ db: Database) throws -> Value.QueryOutput {
-    guard let result = try statement.fetchOne(db)
-    else { throw NotFound() }
-    return result
-  }
-}
-
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-private struct FetchOneStatementPackRequest<each Value: QueryRepresentable>: StatementKeyRequest {
-  let statement: any StructuredQueriesCore.Statement<(repeat each Value)>
-  func fetch(_ db: Database) throws -> (repeat (each Value).QueryOutput) {
     guard let result = try statement.fetchOne(db)
     else { throw NotFound() }
     return result

--- a/Sources/SharingGRDBCore/FetchOne.swift
+++ b/Sources/SharingGRDBCore/FetchOne.swift
@@ -171,9 +171,9 @@ public struct FetchOne<Value: Sendable>: Sendable {
     database: (any DatabaseReader)? = nil
   )
   where
-  Value == S.From.QueryOutput?,
-  S.QueryValue == (),
-  S.Joins == ()
+    Value == S.From.QueryOutput?,
+    S.QueryValue == (),
+    S.Joins == ()
   {
     let statement = statement.selectStar().asSelect().limit(1)
     self.init(statement, database: database)
@@ -191,12 +191,34 @@ public struct FetchOne<Value: Sendable>: Sendable {
     database: (any DatabaseReader)? = nil
   )
   where
-  S.QueryValue: QueryRepresentable,
-  Value == S.QueryValue.QueryOutput?
+    S.QueryValue: QueryRepresentable,
+    Value == S.QueryValue.QueryOutput?
   {
     self.init(
       wrappedValue: nil,
       SQLQueryExpression(statement.query, as: S.QueryValue?.self),
+      database: database
+    )
+  }
+
+  /// Initializes this property with a query associated with an optional value.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default value to associate with this property.
+  ///   - statement: A query associated with the wrapped value.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  public init<V: QueryRepresentable>(
+    _ statement: some StructuredQueriesCore.Statement<V>,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+    V.QueryOutput == V,
+    Value == V?
+  {
+    self.init(
+      wrappedValue: nil,
+      SQLQueryExpression(statement.query, as: V?.self),
       database: database
     )
   }
@@ -338,9 +360,9 @@ extension FetchOne {
     scheduler: some ValueObservationScheduler & Hashable
   )
   where
-  Value == S.From.QueryOutput?,
-  S.QueryValue == (),
-  S.Joins == ()
+    Value == S.From.QueryOutput?,
+    S.QueryValue == (),
+    S.Joins == ()
   {
     let statement = statement.selectStar().asSelect().limit(1)
     self.init(statement, database: database, scheduler: scheduler)
@@ -361,12 +383,38 @@ extension FetchOne {
     scheduler: some ValueObservationScheduler & Hashable
   )
   where
-  S.QueryValue: QueryRepresentable,
-  Value == S.QueryValue.QueryOutput?
+    S.QueryValue: QueryRepresentable,
+    Value == S.QueryValue.QueryOutput?
   {
     self.init(
       wrappedValue: nil,
       SQLQueryExpression(statement.query, as: S.QueryValue?.self),
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
+  /// Initializes this property with a query associated with an optional value.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default value to associate with this property.
+  ///   - statement: A query associated with the wrapped value.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  public init<V: QueryRepresentable>(
+    _ statement: some StructuredQueriesCore.Statement<V>,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+    V.QueryOutput == V,
+    Value == V?
+  {
+    self.init(
+      wrappedValue: nil,
+      SQLQueryExpression(statement.query, as: V?.self),
       database: database,
       scheduler: scheduler
     )
@@ -513,7 +561,6 @@ extension FetchOne: Equatable where Value: Equatable {
       )
     }
 
-
     /// Initializes this property with a query associated with an optional value.
     ///
     /// - Parameters:
@@ -528,9 +575,9 @@ extension FetchOne: Equatable where Value: Equatable {
       animation: Animation
     )
     where
-    Value == S.From.QueryOutput?,
-    S.QueryValue == (),
-    S.Joins == ()
+      Value == S.From.QueryOutput?,
+      S.QueryValue == (),
+      S.Joins == ()
     {
       let statement = statement.selectStar().asSelect().limit(1)
       self.init(statement, database: database, animation: animation)
@@ -551,12 +598,38 @@ extension FetchOne: Equatable where Value: Equatable {
       animation: Animation
     )
     where
-    S.QueryValue: QueryRepresentable,
-    Value == S.QueryValue.QueryOutput?
+      S.QueryValue: QueryRepresentable,
+      Value == S.QueryValue.QueryOutput?
     {
       self.init(
         wrappedValue: nil,
         SQLQueryExpression(statement.query, as: S.QueryValue?.self),
+        database: database,
+        animation: animation
+      )
+    }
+
+    /// Initializes this property with a query associated with an optional value.
+    ///
+    /// - Parameters:
+    ///   - wrappedValue: A default value to associate with this property.
+    ///   - statement: A query associated with the wrapped value.
+    ///   - database: The database to read from. A value of `nil` will use the default database
+    ///     (`@Dependency(\.defaultDatabase)`).
+    ///   - animation: The animation to use for user interface changes that result from changes to
+    ///     the fetched results.
+    public init<V: QueryRepresentable>(
+      _ statement: some StructuredQueriesCore.Statement<V>,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+      V.QueryOutput == V,
+      Value == V?
+    {
+      self.init(
+        wrappedValue: nil,
+        SQLQueryExpression(statement.query, as: V?.self),
         database: database,
         animation: animation
       )

--- a/Sources/SharingGRDBCore/FetchOne.swift
+++ b/Sources/SharingGRDBCore/FetchOne.swift
@@ -107,7 +107,7 @@ public struct FetchOne<Value: Sendable>: Sendable {
     S.QueryValue == (),
     S.Joins == ()
   {
-    let statement = statement.selectStar()
+    let statement = statement.selectStar().asSelect().limit(1)
     self.init(wrappedValue: wrappedValue, statement, database: database)
   }
 
@@ -160,6 +160,47 @@ public struct FetchOne<Value: Sendable>: Sendable {
     )
   }
 
+  /// Initializes this property with a query associated with an optional value.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  public init<S: SelectStatement>(
+    _ statement: S,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+  Value == S.From.QueryOutput?,
+  S.QueryValue == (),
+  S.Joins == ()
+  {
+    let statement = statement.selectStar().asSelect().limit(1)
+    self.init(statement, database: database)
+  }
+
+  /// Initializes this property with a query associated with an optional value.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default value to associate with this property.
+  ///   - statement: A query associated with the wrapped value.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  public init<S: StructuredQueriesCore.Statement>(
+    _ statement: S,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+  S.QueryValue: QueryRepresentable,
+  Value == S.QueryValue.QueryOutput?
+  {
+    self.init(
+      wrappedValue: nil,
+      SQLQueryExpression(statement.query, as: S.QueryValue?.self),
+      database: database
+    )
+  }
+
   /// Replaces the wrapped value with data from the given query.
   ///
   /// - Parameters:
@@ -175,7 +216,7 @@ public struct FetchOne<Value: Sendable>: Sendable {
     S.QueryValue == (),
     S.Joins == ()
   {
-    let statement = statement.selectStar()
+    let statement = statement.selectStar().asSelect().limit(1)
     try await load(statement, database: database)
   }
 
@@ -222,7 +263,7 @@ extension FetchOne {
     S.QueryValue == (),
     S.Joins == ()
   {
-    let statement = statement.selectStar()
+    let statement = statement.selectStar().asSelect().limit(1)
     self.init(wrappedValue: wrappedValue, statement, database: database, scheduler: scheduler)
   }
 
@@ -283,6 +324,54 @@ extension FetchOne {
     )
   }
 
+  /// Initializes this property with a query associated with an optional value.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  public init<S: SelectStatement>(
+    _ statement: S,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+  Value == S.From.QueryOutput?,
+  S.QueryValue == (),
+  S.Joins == ()
+  {
+    let statement = statement.selectStar().asSelect().limit(1)
+    self.init(statement, database: database, scheduler: scheduler)
+  }
+
+  /// Initializes this property with a query associated with an optional value.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default value to associate with this property.
+  ///   - statement: A query associated with the wrapped value.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  ///   - scheduler: The scheduler to observe from. By default, database observation is performed
+  ///     asynchronously on the main queue.
+  public init<S: StructuredQueriesCore.Statement>(
+    _ statement: S,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+  S.QueryValue: QueryRepresentable,
+  Value == S.QueryValue.QueryOutput?
+  {
+    self.init(
+      wrappedValue: nil,
+      SQLQueryExpression(statement.query, as: S.QueryValue?.self),
+      database: database,
+      scheduler: scheduler
+    )
+  }
+
   /// Replaces the wrapped value with data from the given query.
   ///
   /// - Parameters:
@@ -301,7 +390,7 @@ extension FetchOne {
     S.QueryValue == (),
     S.Joins == ()
   {
-    let statement = statement.selectStar()
+    let statement = statement.selectStar().asSelect().limit(1)
     try await load(statement, database: database, scheduler: scheduler)
   }
 
@@ -421,6 +510,55 @@ extension FetchOne: Equatable where Value: Equatable {
         statement,
         database: database,
         scheduler: .animation(animation)
+      )
+    }
+
+
+    /// Initializes this property with a query associated with an optional value.
+    ///
+    /// - Parameters:
+    ///   - statement: A query associated with the wrapped value.
+    ///   - database: The database to read from. A value of `nil` will use the default database
+    ///     (`@Dependency(\.defaultDatabase)`).
+    ///   - animation: The animation to use for user interface changes that result from changes to
+    ///     the fetched results.
+    public init<S: SelectStatement>(
+      _ statement: S,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+    Value == S.From.QueryOutput?,
+    S.QueryValue == (),
+    S.Joins == ()
+    {
+      let statement = statement.selectStar().asSelect().limit(1)
+      self.init(statement, database: database, animation: animation)
+    }
+
+    /// Initializes this property with a query associated with an optional value.
+    ///
+    /// - Parameters:
+    ///   - wrappedValue: A default value to associate with this property.
+    ///   - statement: A query associated with the wrapped value.
+    ///   - database: The database to read from. A value of `nil` will use the default database
+    ///     (`@Dependency(\.defaultDatabase)`).
+    ///   - animation: The animation to use for user interface changes that result from changes to
+    ///     the fetched results.
+    public init<S: StructuredQueriesCore.Statement>(
+      _ statement: S,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+    S.QueryValue: QueryRepresentable,
+    Value == S.QueryValue.QueryOutput?
+    {
+      self.init(
+        wrappedValue: nil,
+        SQLQueryExpression(statement.query, as: S.QueryValue?.self),
+        database: database,
+        animation: animation
       )
     }
 

--- a/Sources/SharingGRDBCore/Internal/Deprecations.swift
+++ b/Sources/SharingGRDBCore/Internal/Deprecations.swift
@@ -1,0 +1,546 @@
+#if canImport(Combine)
+  import Combine
+#endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@available(
+  *,
+  deprecated,
+  message: "Use the '@Selection' macro to bundle multiple values into a value."
+)
+extension FetchAll {
+  @_disfavoredOverload
+  public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
+    wrappedValue: [Element] = [],
+    _ statement: S,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+    Element == (S.From.QueryOutput, repeat (each J).QueryOutput),
+    S.QueryValue == (),
+    S.From.QueryOutput: Sendable,
+    S.Joins == (repeat each J),
+    repeat (each J).QueryOutput: Sendable
+  {
+    let statement = statement.selectStar().asSelect()
+    sharedReader = SharedReader(
+      wrappedValue: wrappedValue,
+      .fetch(FetchAllStatementPackRequest(statement: statement), database: database)
+    )
+  }
+
+  @_disfavoredOverload
+  public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
+    wrappedValue: [Element] = [],
+    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+    Element == (V1.QueryOutput, repeat (each V2).QueryOutput),
+    V1.QueryOutput: Sendable,
+    repeat (each V2).QueryOutput: Sendable
+  {
+    sharedReader = SharedReader(
+      wrappedValue: wrappedValue,
+      .fetch(
+        FetchAllStatementPackRequest(statement: statement),
+        database: database
+      )
+    )
+  }
+
+  @_disfavoredOverload
+  public func load<S: SelectStatement, each J: StructuredQueriesCore.Table>(
+    _ statement: S,
+    database: (any DatabaseReader)? = nil
+  ) async throws
+  where
+    Element == (S.From.QueryOutput, repeat (each J).QueryOutput),
+    S.QueryValue == (),
+    S.From.QueryOutput: Sendable,
+    S.Joins == (repeat each J),
+    repeat (each J).QueryOutput: Sendable
+  {
+    let statement = statement.selectStar().asSelect()
+    try await sharedReader.load(
+      .fetch(
+        FetchAllStatementPackRequest(statement: statement),
+        database: database
+      )
+    )
+  }
+
+  @_disfavoredOverload
+  public func load<V1: QueryRepresentable, each V2: QueryRepresentable>(
+    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
+    database: (any DatabaseReader)? = nil
+  ) async throws
+  where
+    Element == (V1.QueryOutput, repeat (each V2).QueryOutput),
+    V1.QueryOutput: Sendable,
+    repeat (each V2).QueryOutput: Sendable
+  {
+    try await sharedReader.load(
+      .fetch(
+        FetchAllStatementPackRequest(statement: statement),
+        database: database
+      )
+    )
+  }
+
+  @_disfavoredOverload
+  public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
+    wrappedValue: [Element] = [],
+    _ statement: S,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+    Element == (S.From.QueryOutput, repeat (each J).QueryOutput),
+    S.QueryValue == (),
+    S.From.QueryOutput: Sendable,
+    S.Joins == (repeat each J),
+    repeat (each J).QueryOutput: Sendable
+  {
+    let statement = statement.selectStar().asSelect()
+    sharedReader = SharedReader(
+      wrappedValue: wrappedValue,
+      .fetch(
+        FetchAllStatementPackRequest(statement: statement),
+        database: database,
+        scheduler: scheduler
+      )
+    )
+  }
+
+  @_disfavoredOverload
+  public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
+    wrappedValue: [Element] = [],
+    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+    Element == (V1.QueryOutput, repeat (each V2).QueryOutput),
+    V1.QueryOutput: Sendable,
+    repeat (each V2).QueryOutput: Sendable
+  {
+    sharedReader = SharedReader(
+      wrappedValue: wrappedValue,
+      .fetch(
+        FetchAllStatementPackRequest(statement: statement),
+        database: database,
+        scheduler: scheduler
+      )
+    )
+  }
+
+  @_disfavoredOverload
+  public func load<S: SelectStatement, each J: StructuredQueriesCore.Table>(
+    _ statement: S,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  ) async throws
+  where
+    Element == (S.From.QueryOutput, repeat (each J).QueryOutput),
+    S.QueryValue == (),
+    S.From.QueryOutput: Sendable,
+    S.Joins == (repeat each J),
+    repeat (each J).QueryOutput: Sendable
+  {
+    let statement = statement.selectStar().asSelect()
+    try await sharedReader.load(
+      .fetch(
+        FetchAllStatementPackRequest(statement: statement),
+        database: database,
+        scheduler: scheduler
+      )
+    )
+  }
+
+  @_disfavoredOverload
+  public func load<V1: QueryRepresentable, each V2: QueryRepresentable>(
+    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  ) async throws
+  where
+    Element == (V1.QueryOutput, repeat (each V2).QueryOutput),
+    V1.QueryOutput: Sendable,
+    repeat (each V2).QueryOutput: Sendable
+  {
+    try await sharedReader.load(
+      .fetch(
+        FetchAllStatementPackRequest(statement: statement),
+        database: database
+      )
+    )
+  }
+
+  #if canImport(SwiftUI)
+    public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
+      wrappedValue: [Element] = [],
+      _ statement: S,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+      Element == (S.From.QueryOutput, repeat (each J).QueryOutput),
+      S.QueryValue == (),
+      S.From.QueryOutput: Sendable,
+      S.Joins == (repeat each J),
+      repeat (each J).QueryOutput: Sendable
+    {
+      let statement = statement.selectStar().asSelect()
+      sharedReader = SharedReader(
+        wrappedValue: wrappedValue,
+        .fetch(
+          FetchAllStatementPackRequest(statement: statement),
+          database: database,
+          animation: animation
+        )
+      )
+    }
+
+    @_disfavoredOverload
+    public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
+      wrappedValue: [Element] = [],
+      _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+      Element == (V1.QueryOutput, repeat (each V2).QueryOutput),
+      V1.QueryOutput: Sendable,
+      repeat (each V2).QueryOutput: Sendable
+    {
+      sharedReader = SharedReader(
+        wrappedValue: wrappedValue,
+        .fetch(
+          FetchAllStatementPackRequest(statement: statement),
+          database: database,
+          animation: animation
+        )
+      )
+    }
+
+    @_disfavoredOverload
+    public func load<S: SelectStatement, each J: StructuredQueriesCore.Table>(
+      _ statement: S,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    ) async throws
+    where
+      Element == (S.From.QueryOutput, repeat (each J).QueryOutput),
+      S.QueryValue == (),
+      S.From.QueryOutput: Sendable,
+      S.Joins == (repeat each J),
+      repeat (each J).QueryOutput: Sendable
+    {
+      let statement = statement.selectStar().asSelect()
+      try await sharedReader.load(
+        .fetch(
+          FetchAllStatementPackRequest(statement: statement),
+          database: database,
+          animation: animation
+        )
+      )
+    }
+
+    @_disfavoredOverload
+    public func load<V1: QueryRepresentable, each V2: QueryRepresentable>(
+      _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    ) async throws
+    where
+      Element == (V1.QueryOutput, repeat (each V2).QueryOutput),
+      V1.QueryOutput: Sendable,
+      repeat (each V2).QueryOutput: Sendable
+    {
+      try await sharedReader.load(
+        .fetch(
+          FetchAllStatementPackRequest(statement: statement),
+          database: database,
+          animation: animation
+        )
+      )
+    }
+  #endif
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+private struct FetchAllStatementPackRequest<each Value: QueryRepresentable>: StatementKeyRequest {
+  let statement: any StructuredQueriesCore.Statement<(repeat each Value)>
+  func fetch(_ db: Database) throws -> [(repeat (each Value).QueryOutput)] {
+    try statement.fetchAll(db)
+  }
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@available(
+  *,
+  deprecated,
+  message: "Use the '@Selection' macro to bundle multiple values into a value."
+)
+extension FetchOne {
+  @_disfavoredOverload
+  public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
+    wrappedValue: (S.From.QueryOutput, repeat (each J).QueryOutput),
+    _ statement: S,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+    Value == (S.From.QueryOutput, repeat (each J).QueryOutput),
+    S.QueryValue == (),
+    S.Joins == (repeat each J)
+  {
+    let statement = statement.selectStar().asSelect()
+    sharedReader = SharedReader(
+      wrappedValue: wrappedValue,
+      .fetch(
+        FetchOneStatementPackRequest(statement: statement),
+        database: database
+      )
+    )
+  }
+
+  @_disfavoredOverload
+  public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
+    wrappedValue: (V1.QueryOutput, repeat (each V2).QueryOutput),
+    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
+    database: (any DatabaseReader)? = nil
+  )
+  where
+    Value == (V1.QueryOutput, repeat (each V2).QueryOutput)
+  {
+    sharedReader = SharedReader(
+      wrappedValue: wrappedValue,
+      .fetch(
+        FetchOneStatementPackRequest(statement: statement),
+        database: database
+      )
+    )
+  }
+
+  @_disfavoredOverload
+  public func load<S: SelectStatement, each J: StructuredQueriesCore.Table>(
+    _ statement: S,
+    database: (any DatabaseReader)? = nil
+  ) async throws
+  where
+    Value == (S.From.QueryOutput, repeat (each J).QueryOutput),
+    S.QueryValue == (),
+    S.Joins == (repeat each J)
+  {
+    let statement = statement.selectStar().asSelect()
+    try await sharedReader.load(
+      .fetch(
+        FetchOneStatementPackRequest(statement: statement),
+        database: database
+      )
+    )
+  }
+
+  /// Replaces the wrapped value with data from the given query.
+  ///
+  /// - Parameters:
+  ///   - statement: A query associated with the wrapped value.
+  ///   - database: The database to read from. A value of `nil` will use the default database
+  ///     (`@Dependency(\.defaultDatabase)`).
+  @_disfavoredOverload
+  public func load<V1: QueryRepresentable, each V2: QueryRepresentable>(
+    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
+    database: (any DatabaseReader)? = nil
+  ) async throws
+  where
+    Value == (V1.QueryOutput, repeat (each V2).QueryOutput)
+  {
+    try await sharedReader.load(
+      .fetch(
+        FetchOneStatementPackRequest(statement: statement),
+        database: database
+      )
+    )
+  }
+
+  @_disfavoredOverload
+  public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
+    wrappedValue: (S.From.QueryOutput, repeat (each J).QueryOutput),
+    _ statement: S,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+    Value == (S.From.QueryOutput, repeat (each J).QueryOutput),
+    S.QueryValue == (),
+    S.Joins == (repeat each J)
+  {
+    let statement = statement.selectStar().asSelect()
+    sharedReader = SharedReader(
+      wrappedValue: wrappedValue,
+      .fetch(
+        FetchOneStatementPackRequest(statement: statement),
+        database: database,
+        scheduler: scheduler
+      )
+    )
+  }
+
+  @_disfavoredOverload
+  public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
+    wrappedValue: (V1.QueryOutput, repeat (each V2).QueryOutput),
+    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  )
+  where
+    Value == (V1.QueryOutput, repeat (each V2).QueryOutput)
+  {
+    sharedReader = SharedReader(
+      wrappedValue: wrappedValue,
+      .fetch(
+        FetchOneStatementPackRequest(statement: statement),
+        database: database,
+        scheduler: scheduler
+      )
+    )
+  }
+
+  @_disfavoredOverload
+  public func load<S: SelectStatement, each J: StructuredQueriesCore.Table>(
+    _ statement: S,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  ) async throws
+  where
+    Value == (S.From.QueryOutput, repeat (each J).QueryOutput),
+    S.QueryValue == (),
+    S.Joins == (repeat each J)
+  {
+    let statement = statement.selectStar().asSelect()
+    try await sharedReader.load(
+      .fetch(
+        FetchOneStatementPackRequest(statement: statement),
+        database: database,
+        scheduler: scheduler
+      )
+    )
+  }
+
+  @_disfavoredOverload
+  public func load<V1: QueryRepresentable, each V2: QueryRepresentable>(
+    _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
+    database: (any DatabaseReader)? = nil,
+    scheduler: some ValueObservationScheduler & Hashable
+  ) async throws
+  where
+    Value == (V1.QueryOutput, repeat (each V2).QueryOutput)
+  {
+    try await sharedReader.load(
+      .fetch(
+        FetchOneStatementPackRequest(statement: statement),
+        database: database,
+        scheduler: scheduler
+      )
+    )
+  }
+
+  #if canImport(SwiftUI)
+    @_disfavoredOverload
+    public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
+      wrappedValue: (S.From.QueryOutput, repeat (each J).QueryOutput),
+      _ statement: S,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+      Value == (S.From.QueryOutput, repeat (each J).QueryOutput),
+      S.QueryValue == (),
+      S.Joins == (repeat each J)
+    {
+      let statement = statement.selectStar().asSelect()
+      sharedReader = SharedReader(
+        wrappedValue: wrappedValue,
+        .fetch(
+          FetchOneStatementPackRequest(statement: statement),
+          database: database,
+          animation: animation
+        )
+      )
+    }
+
+    @_disfavoredOverload
+    public init<V1: QueryRepresentable, each V2: QueryRepresentable>(
+      wrappedValue: (V1.QueryOutput, repeat (each V2).QueryOutput),
+      _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    )
+    where
+      Value == (V1.QueryOutput, repeat (each V2).QueryOutput)
+    {
+      sharedReader = SharedReader(
+        wrappedValue: wrappedValue,
+        .fetch(
+          FetchOneStatementPackRequest(statement: statement),
+          database: database,
+          animation: animation
+        )
+      )
+    }
+
+    @_disfavoredOverload
+    public func load<S: SelectStatement, each J: StructuredQueriesCore.Table>(
+      _ statement: S,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    ) async throws
+    where
+      Value == (S.From.QueryOutput, repeat (each J).QueryOutput),
+      S.QueryValue == (),
+      S.Joins == (repeat each J)
+    {
+      let statement = statement.selectStar().asSelect()
+      try await sharedReader.load(
+        .fetch(
+          FetchOneStatementPackRequest(statement: statement),
+          database: database,
+          animation: animation
+        )
+      )
+    }
+
+    @_disfavoredOverload
+    public func load<V1: QueryRepresentable, each V2: QueryRepresentable>(
+      _ statement: some StructuredQueriesCore.Statement<(V1, repeat each V2)>,
+      database: (any DatabaseReader)? = nil,
+      animation: Animation
+    ) async throws
+    where
+      Value == (V1.QueryOutput, repeat (each V2).QueryOutput)
+    {
+      try await sharedReader.load(
+        .fetch(
+          FetchOneStatementPackRequest(statement: statement),
+          database: database,
+          animation: animation
+        )
+      )
+    }
+
+  #endif
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+private struct FetchOneStatementPackRequest<each Value: QueryRepresentable>: StatementKeyRequest {
+  let statement: any StructuredQueriesCore.Statement<(repeat each Value)>
+  func fetch(_ db: Database) throws -> (repeat (each Value).QueryOutput) {
+    guard let result = try statement.fetchOne(db)
+    else { throw NotFound() }
+    return result
+  }
+}

--- a/Sources/SharingGRDBCore/Internal/Deprecations.swift
+++ b/Sources/SharingGRDBCore/Internal/Deprecations.swift
@@ -5,6 +5,8 @@
   import SwiftUI
 #endif
 
+// NB: Deprecated after 0.2.2
+
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
 @available(
   *,
@@ -25,7 +27,7 @@ extension FetchAll {
     S.Joins == (repeat each J),
     repeat (each J).QueryOutput: Sendable
   {
-    let statement = statement.selectStar().asSelect()
+    let statement = statement.selectStar()
     sharedReader = SharedReader(
       wrappedValue: wrappedValue,
       .fetch(FetchAllStatementPackRequest(statement: statement), database: database)
@@ -64,7 +66,7 @@ extension FetchAll {
     S.Joins == (repeat each J),
     repeat (each J).QueryOutput: Sendable
   {
-    let statement = statement.selectStar().asSelect()
+    let statement = statement.selectStar()
     try await sharedReader.load(
       .fetch(
         FetchAllStatementPackRequest(statement: statement),
@@ -105,7 +107,7 @@ extension FetchAll {
     S.Joins == (repeat each J),
     repeat (each J).QueryOutput: Sendable
   {
-    let statement = statement.selectStar().asSelect()
+    let statement = statement.selectStar()
     sharedReader = SharedReader(
       wrappedValue: wrappedValue,
       .fetch(
@@ -151,7 +153,7 @@ extension FetchAll {
     S.Joins == (repeat each J),
     repeat (each J).QueryOutput: Sendable
   {
-    let statement = statement.selectStar().asSelect()
+    let statement = statement.selectStar()
     try await sharedReader.load(
       .fetch(
         FetchAllStatementPackRequest(statement: statement),
@@ -194,7 +196,7 @@ extension FetchAll {
       S.Joins == (repeat each J),
       repeat (each J).QueryOutput: Sendable
     {
-      let statement = statement.selectStar().asSelect()
+      let statement = statement.selectStar()
       sharedReader = SharedReader(
         wrappedValue: wrappedValue,
         .fetch(
@@ -240,7 +242,7 @@ extension FetchAll {
       S.Joins == (repeat each J),
       repeat (each J).QueryOutput: Sendable
     {
-      let statement = statement.selectStar().asSelect()
+      let statement = statement.selectStar()
       try await sharedReader.load(
         .fetch(
           FetchAllStatementPackRequest(statement: statement),
@@ -298,7 +300,7 @@ extension FetchOne {
     S.QueryValue == (),
     S.Joins == (repeat each J)
   {
-    let statement = statement.selectStar().asSelect()
+    let statement = statement.selectStar()
     sharedReader = SharedReader(
       wrappedValue: wrappedValue,
       .fetch(
@@ -336,7 +338,7 @@ extension FetchOne {
     S.QueryValue == (),
     S.Joins == (repeat each J)
   {
-    let statement = statement.selectStar().asSelect()
+    let statement = statement.selectStar()
     try await sharedReader.load(
       .fetch(
         FetchOneStatementPackRequest(statement: statement),
@@ -379,7 +381,7 @@ extension FetchOne {
     S.QueryValue == (),
     S.Joins == (repeat each J)
   {
-    let statement = statement.selectStar().asSelect()
+    let statement = statement.selectStar()
     sharedReader = SharedReader(
       wrappedValue: wrappedValue,
       .fetch(
@@ -421,7 +423,7 @@ extension FetchOne {
     S.QueryValue == (),
     S.Joins == (repeat each J)
   {
-    let statement = statement.selectStar().asSelect()
+    let statement = statement.selectStar()
     try await sharedReader.load(
       .fetch(
         FetchOneStatementPackRequest(statement: statement),
@@ -462,7 +464,7 @@ extension FetchOne {
       S.QueryValue == (),
       S.Joins == (repeat each J)
     {
-      let statement = statement.selectStar().asSelect()
+      let statement = statement.selectStar()
       sharedReader = SharedReader(
         wrappedValue: wrappedValue,
         .fetch(
@@ -504,7 +506,7 @@ extension FetchOne {
       S.QueryValue == (),
       S.Joins == (repeat each J)
     {
-      let statement = statement.selectStar().asSelect()
+      let statement = statement.selectStar()
       try await sharedReader.load(
         .fetch(
           FetchOneStatementPackRequest(statement: statement),

--- a/Sources/StructuredQueriesGRDBCore/Statement+GRDB.swift
+++ b/Sources/StructuredQueriesGRDBCore/Statement+GRDB.swift
@@ -174,7 +174,7 @@ extension SelectStatement where QueryValue == (), Joins == () {
   @_documentation(visibility: private)
   @inlinable
   public func fetchOne(_ db: Database) throws -> From.QueryOutput? {
-    try fetchCursor(db).next()
+    try asSelect().limit(1).fetchCursor(db).next()
   }
 
   /// Returns a cursor to all values fetched from the database.
@@ -213,7 +213,7 @@ extension SelectStatement where QueryValue == () {
     _ db: Database
   ) throws -> (From.QueryOutput, repeat (each J).QueryOutput)?
   where Joins == (repeat each J) {
-    try fetchCursor(db).next()
+    try asSelect().limit(1).fetchCursor(db).next()
   }
 
   /// Returns a cursor to all values fetched from the database.

--- a/Tests/SharingGRDBTests/FetchTests.swift
+++ b/Tests/SharingGRDBTests/FetchTests.swift
@@ -54,6 +54,5 @@ extension DatabaseWriter where Self == DatabaseQueue {
 func compileTimeTests() {
   @FetchAll(#sql("SELECT * FROM records")) var records: [Record]
   @FetchOne(#sql("SELECT count(*) FROM records")) var count = 0
-  // TODO: Add overload to allow omission of '= nil'
-  @FetchOne(#sql("SELECT * FROM records LIMIT 1")) var record: Record? = nil
+  @FetchOne(#sql("SELECT * FROM records LIMIT 1")) var record: Record?
 }

--- a/Tests/SharingGRDBTests/FetchTests.swift
+++ b/Tests/SharingGRDBTests/FetchTests.swift
@@ -50,3 +50,10 @@ extension DatabaseWriter where Self == DatabaseQueue {
     return database
   }
 }
+
+func compileTimeTests() {
+  @FetchAll(#sql("SELECT * FROM records")) var records: [Record]
+  @FetchOne(#sql("SELECT count(*) FROM records")) var count = 0
+  // TODO: Add overload to allow omission of '= nil'
+  @FetchOne(#sql("SELECT * FROM records LIMIT 1")) var record: Record? = nil
+}


### PR DESCRIPTION
Introduce the following changes:

- `@FetchOne` and `fetchOne` will automatically introduce `LIMIT 1` clauses to select statements.
- `@FetchOne` can now be assigned an _optional_ value for a given statement and fetch the first row or `nil`.
- `@FetchAll` and `@FetchOne` overloads for parameter packs have been deprecated. There are many overloads to maintain to support them, but they are not very ergonomic. We provide a far better tool for packing values together, and that's the `@Selection` macro, so let's steer folks that direction.