### PR TITLE
Disfavor deprecated init.

### DIFF
--- a/Examples/Reminders/RemindersApp.swift
+++ b/Examples/Reminders/RemindersApp.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 @main
 struct RemindersApp: App {
+
+
   init() {
     try! prepareDependencies {
       $0.defaultDatabase = try Reminders.appDatabase()

--- a/Examples/Reminders/RemindersApp.swift
+++ b/Examples/Reminders/RemindersApp.swift
@@ -3,8 +3,6 @@ import SwiftUI
 
 @main
 struct RemindersApp: App {
-
-
   init() {
     try! prepareDependencies {
       $0.defaultDatabase = try Reminders.appDatabase()

--- a/Sources/SharingGRDBCore/Internal/Deprecations.swift
+++ b/Sources/SharingGRDBCore/Internal/Deprecations.swift
@@ -183,6 +183,7 @@ extension FetchAll {
   }
 
   #if canImport(SwiftUI)
+    @_disfavoredOverload
     public init<S: SelectStatement, each J: StructuredQueriesCore.Table>(
       wrappedValue: [Element] = [],
       _ statement: S,


### PR DESCRIPTION
With #63 we created the potential for some ambiguous inits. This does not currently work:

```swift
@FetchAll(Reminder.order(by: \.isCompleted), animation: .default)
var reminders: [Reminder]
```

So I am disfavoring the deprecated init to make this pick the right one.