### PR TITLE
Use an immediate schedule in FetchKey.

### DIFF
--- a/Tests/SharingGRDBTests/FetchAllTests.swift
+++ b/Tests/SharingGRDBTests/FetchAllTests.swift
@@ -1,0 +1,76 @@
+import Dependencies
+import DependenciesTestSupport
+import Foundation
+import SharingGRDB
+import Testing
+
+@Suite(.dependency(\.defaultDatabase, try .database()))
+struct FetchAllTests {
+  @Dependency(\.defaultDatabase) var database
+
+  @MainActor
+  @Test func concurrency() async throws {
+    let count = 1_000
+    try await database.write { db in
+      try Record.delete().execute(db)
+    }
+
+    @FetchAll var records: [Record]
+
+    await withThrowingTaskGroup { group in
+      for index in 1...count {
+        group.addTask {
+          try await database.write { db in
+            try Record.insert(Record(id: index)).execute(db)
+          }
+        }
+      }
+    }
+
+    try await $records.load()
+    #expect(records == (1...count).map { Record(id: $0) })
+
+    await withThrowingTaskGroup { group in
+      for index in 1...(count/2) {
+        group.addTask {
+          try await database.write { db in
+            try Record.find(index * 2).delete().execute(db)
+          }
+        }
+      }
+    }
+
+    try await $records.load()
+    #expect(records == (0...(count/2-1)).map { Record(id: $0 * 2 + 1) })
+  }
+}
+
+@Table
+private struct Record: Equatable {
+  let id: Int
+  @Column(as: Date.UnixTimeRepresentation.self)
+  var date = Date(timeIntervalSince1970: 42)
+  @Column(as: Date?.UnixTimeRepresentation.self)
+  var optionalDate: Date?
+}
+extension DatabaseWriter where Self == DatabaseQueue {
+  fileprivate static func database() throws -> DatabaseQueue {
+    let database = try DatabaseQueue()
+    try database.write { db in
+      try #sql(
+        """
+        CREATE TABLE "records" (
+          "id" INTEGER PRIMARY KEY AUTOINCREMENT
+          , "date" INTEGER NOT NULL DEFAULT 42
+          , "optionalDate" INTEGER
+        )
+        """
+      )
+      .execute(db)
+      for _ in 1...3 {
+        _ = try Record.insert(Record.Draft()).execute(db)
+      }
+    }
+    return database
+  }
+}

--- a/Tests/SharingGRDBTests/FetchTests.swift
+++ b/Tests/SharingGRDBTests/FetchTests.swift
@@ -10,31 +10,26 @@ import Testing
 struct FetchTests {
   @Test func bareFetchAll() async throws {
     @FetchAll var records: [Record]
-    try await Task.sleep(nanoseconds: 100_000_000)
     #expect(records == [Record(id: 1), Record(id: 2), Record(id: 3)])
   }
 
   @Test func fetchAllWithQuery() async throws {
     @FetchAll(Record.where { $0.id > 1 }) var records: [Record]
-    try await Task.sleep(nanoseconds: 100_000_000)
     #expect(records == [Record(id: 2), Record(id: 3)])
   }
 
   @Test func fetchOneCountWithQuery() async throws {
     @FetchOne(Record.where { $0.id > 1 }.count()) var recordsCount = 0
-    try await Task.sleep(nanoseconds: 100_000_000)
     #expect(recordsCount == 2)
   }
   
   @Test func bareFetchOneOptional() async throws {
     @FetchOne var record: Record?
-    try await Task.sleep(nanoseconds: 100_000_000)
     #expect(record != nil)
   }
   
   @Test func fetchOneOptionalWithQuery() async throws {
     @FetchOne(#sql("SELECT * FROM records LIMIT 1")) var record: Record?
-    try await Task.sleep(nanoseconds: 100_000_000)
     #expect(record != nil)
   }
 }

--- a/Tests/SharingGRDBTests/IntegrationTests.swift
+++ b/Tests/SharingGRDBTests/IntegrationTests.swift
@@ -18,19 +18,19 @@ struct IntegrationTests {
       _ = try SyncUp.insert(SyncUp.Draft(isActive: true, title: "Engineering"))
         .execute(db)
     }
-    try await Task.sleep(nanoseconds: 100_000_000)
+    try await $syncUps.load()
     #expect(syncUps == [SyncUp(id: 1, isActive: true, title: "Engineering")])
     try await database.write { db in
       _ = try SyncUp.upsert(SyncUp.Draft(id: 1, isActive: false, title: "Engineering"))
         .execute(db)
     }
-    try await Task.sleep(nanoseconds: 100_000_000)
+    try await $syncUps.load()
     #expect(syncUps == [])
     try await database.write { db in
       _ = try SyncUp.upsert(SyncUp.Draft(id: 1, isActive: true, title: "Engineering"))
         .execute(db)
     }
-    try await Task.sleep(nanoseconds: 100_000_000)
+    try await $syncUps.load()
     #expect(syncUps == [SyncUp(id: 1, isActive: true, title: "Engineering")])
   }
 
@@ -43,19 +43,19 @@ struct IntegrationTests {
       _ = try SyncUp.insert(SyncUp.Draft(isActive: true, title: "Engineering"))
         .execute(db)
     }
-    try await Task.sleep(nanoseconds: 100_000_000)
+    try await $syncUps.load()
     #expect(syncUps == [SyncUp(id: 1, isActive: true, title: "Engineering")])
     try await database.write { db in
       _ = try SyncUp.upsert(SyncUp.Draft(id: 1, isActive: false, title: "Engineering"))
         .execute(db)
     }
-    try await Task.sleep(nanoseconds: 100_000_000)
+    try await $syncUps.load()
     #expect(syncUps == [])
     try await database.write { db in
       _ = try SyncUp.upsert(SyncUp.Draft(id: 1, isActive: true, title: "Engineering"))
         .execute(db)
     }
-    try await Task.sleep(nanoseconds: 100_000_000)
+    try await $syncUps.load()
     #expect(syncUps == [SyncUp(id: 1, isActive: true, title: "Engineering")])
   }
 }


### PR DESCRIPTION
Since `@SharedReader` takes care of all synchronization for us, we do not need to incur an additional thread hop with value observation schedulers. This has the added benefit of making tests a lot easier to write since we don't have to wait around for an initial value.