### PR TITLE
Fix FetchOne load() for optionals

### DIFF
--- a/Tests/SharingGRDBTests/FetchTests.swift
+++ b/Tests/SharingGRDBTests/FetchTests.swift
@@ -32,10 +32,17 @@ struct FetchTests {
     @FetchOne(#sql("SELECT * FROM records LIMIT 1")) var record: Record?
     #expect(record != nil)
   }
+
+  @Test func fetchOneOptionalWithStructurdQueriesFind() async throws {
+    @FetchOne(Record.find(1)) var record: Record?
+    #expect(record != nil)
+    try await $record.load(Record.find(1))
+    #expect(record != nil)
+  }
 }
 
 @Table
-private struct Record: Equatable {
+private struct Record: Equatable, Identifiable {
   let id: Int
 }
 extension DatabaseWriter where Self == DatabaseQueue {


### PR DESCRIPTION
Adds an overload for `FetchOne.load` where the value is optional. Previously this compiler error occurred:

![image](https://github.com/user-attachments/assets/2d67a0ca-95c6-40cb-903c-9ef97c6f85db)

I added the minimal to fix it, not sure if there are other cases!
