### PR TITLE
Fix hash availability of Animation.

### DIFF
--- a/Sources/SharingGRDBCore/Fetch.swift
+++ b/Sources/SharingGRDBCore/Fetch.swift
@@ -164,6 +164,7 @@ extension Fetch: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init(
       wrappedValue: Value,
       _ request: some FetchKeyRequest<Value>,
@@ -184,6 +185,7 @@ extension Fetch: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public func load(
       _ request: some FetchKeyRequest<Value>,
       database: (any DatabaseReader)? = nil,

--- a/Sources/SharingGRDBCore/FetchAll.swift
+++ b/Sources/SharingGRDBCore/FetchAll.swift
@@ -364,6 +364,7 @@ extension FetchAll: Equatable where Element: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init(
       wrappedValue: [Element] = [],
       database: (any DatabaseReader)? = nil,
@@ -381,6 +382,7 @@ extension FetchAll: Equatable where Element: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<S: SelectStatement>(
       wrappedValue: [Element] = [],
       _ statement: S,
@@ -409,6 +411,7 @@ extension FetchAll: Equatable where Element: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<V: QueryRepresentable>(
       wrappedValue: [Element] = [],
       _ statement: some StructuredQueriesCore.Statement<V>,
@@ -435,6 +438,7 @@ extension FetchAll: Equatable where Element: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<S: StructuredQueriesCore.Statement<Element>>(
       wrappedValue: [Element] = [],
       _ statement: S,
@@ -461,6 +465,7 @@ extension FetchAll: Equatable where Element: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public func load<S: SelectStatement>(
       _ statement: S,
       database: (any DatabaseReader)? = nil,
@@ -484,6 +489,7 @@ extension FetchAll: Equatable where Element: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public func load<V: QueryRepresentable>(
       _ statement: some StructuredQueriesCore.Statement<V>,
       database: (any DatabaseReader)? = nil,

--- a/Sources/SharingGRDBCore/FetchKey+SwiftUI.swift
+++ b/Sources/SharingGRDBCore/FetchKey+SwiftUI.swift
@@ -18,6 +18,7 @@
     @available(macOS, deprecated: 9999, message: "Use the '@Fetch' property wrapper, instead")
     @available(tvOS, deprecated: 9999, message: "Use the '@Fetch' property wrapper, instead")
     @available(watchOS, deprecated: 9999, message: "Use the '@Fetch' property wrapper, instead")
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public static func fetch<Value>(
       _ request: some FetchKeyRequest<Value>,
       database: (any DatabaseReader)? = nil,
@@ -41,6 +42,7 @@
     @available(macOS, deprecated: 9999, message: "Use the '@Fetch' property wrapper, instead")
     @available(tvOS, deprecated: 9999, message: "Use the '@Fetch' property wrapper, instead")
     @available(watchOS, deprecated: 9999, message: "Use the '@Fetch' property wrapper, instead")
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public static func fetch<Records: RangeReplaceableCollection>(
       _ request: some FetchKeyRequest<Records>,
       database: (any DatabaseReader)? = nil,
@@ -65,6 +67,7 @@
     @available(macOS, deprecated: 9999, message: "Use '@FetchAll' and '#sql', instead")
     @available(tvOS, deprecated: 9999, message: "Use '@FetchAll' and '#sql', instead")
     @available(watchOS, deprecated: 9999, message: "Use '@FetchAll' and '#sql', instead")
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public static func fetchAll<Record: FetchableRecord>(
       sql: String,
       arguments: StatementArguments = StatementArguments(),
@@ -95,6 +98,7 @@
     @available(macOS, deprecated: 9999, message: "Use '@FetchOne' and '#sql', instead")
     @available(tvOS, deprecated: 9999, message: "Use '@FetchOne' and '#sql', instead")
     @available(watchOS, deprecated: 9999, message: "Use '@FetchOne' and '#sql', instead")
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public static func fetchOne<Value: DatabaseValueConvertible>(
       sql: String,
       arguments: StatementArguments = StatementArguments(),
@@ -111,7 +115,7 @@
     }
   }
 
-  package struct AnimatedScheduler: ValueObservationScheduler, Hashable {
+package struct AnimatedScheduler: ValueObservationScheduler, Equatable {
     let animation: Animation
     package func immediateInitialValue() -> Bool { true }
     package func schedule(_ action: @escaping @Sendable () -> Void) {
@@ -122,6 +126,9 @@
       }
     }
   }
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension AnimatedScheduler: Hashable {}
 
   extension ValueObservationScheduler where Self == AnimatedScheduler {
     package static func animation(_ animation: Animation) -> Self {

--- a/Sources/SharingGRDBCore/FetchOne.swift
+++ b/Sources/SharingGRDBCore/FetchOne.swift
@@ -834,6 +834,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init(
       wrappedValue: sending Value,
       database: (any DatabaseReader)? = nil,
@@ -853,6 +854,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init(
       wrappedValue: sending Value,
       database: (any DatabaseReader)? = nil,
@@ -875,6 +877,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<S: SelectStatement>(
       wrappedValue: Value,
       _ statement: S,
@@ -903,6 +906,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<V: QueryRepresentable>(
       wrappedValue: Value,
       _ statement: some StructuredQueriesCore.Statement<V>,
@@ -929,6 +933,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<V: QueryRepresentable>(
       wrappedValue: Value = nil,
       _ statement: some StructuredQueriesCore.Statement<V>,
@@ -955,6 +960,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<S: StructuredQueriesCore.Statement<Value>>(
       wrappedValue: Value,
       _ statement: S,
@@ -982,6 +988,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<S: SelectStatement>(
       wrappedValue: Value = ._none,
       _ statement: S,
@@ -1011,6 +1018,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init<S: StructuredQueriesCore.Statement>(
       wrappedValue: Value = ._none,
       _ statement: S,
@@ -1040,6 +1048,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public init(
       wrappedValue: Value = ._none,
       _ statement: some StructuredQueriesCore.Statement<Value>,
@@ -1067,6 +1076,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public func load<S: SelectStatement>(
       _ statement: S,
       database: (any DatabaseReader)? = nil,
@@ -1088,6 +1098,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public func load<V: QueryRepresentable>(
       _ statement: some StructuredQueriesCore.Statement<V>,
       database: (any DatabaseReader)? = nil,
@@ -1107,6 +1118,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public func load<V: QueryRepresentable>(
       _ statement: some StructuredQueriesCore.Statement<V>,
       database: (any DatabaseReader)? = nil,
@@ -1126,6 +1138,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public func load<S: SelectStatement>(
       _ statement: S,
       database: (any DatabaseReader)? = nil,
@@ -1148,6 +1161,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public func load<S: StructuredQueriesCore.Statement>(
       _ statement: S,
       database: (any DatabaseReader)? = nil,
@@ -1170,6 +1184,7 @@ extension FetchOne: Equatable where Value: Equatable {
     ///     (`@Dependency(\.defaultDatabase)`).
     ///   - animation: The animation to use for user interface changes that result from changes to
     ///     the fetched results.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     public func load(
       _ statement: some StructuredQueriesCore.Statement<Value>,
       database: (any DatabaseReader)? = nil,


### PR DESCRIPTION
Apparently `SwiftuI.Animation` was made hashable only in the iOS 17 era, but due to a compiler bug Swift will happily synthesize a conformance to `Hashable` without checking availability restrictions. So, we have to enforce this ourselves.