### PR TITLE
Improve `SyncEngine.init`

### DIFF
--- a/Examples/CloudKitDemo/CloudKitDemoApp.swift
+++ b/Examples/CloudKitDemo/CloudKitDemoApp.swift
@@ -30,11 +30,8 @@ struct CloudKitDemoApp: App {
       try! prepareDependencies {
         $0.defaultDatabase = try appDatabase()
         $0.defaultSyncEngine = try SyncEngine(
-          container: CKContainer(identifier: "iCloud.co.pointfree.SQLiteData.demos.CloudKitDemo"),
-          database: $0.defaultDatabase,
-          tables: [
-            Counter.self
-          ]
+          for: $0.defaultDatabase,
+          tables: Counter.self
         )
       }
       return true

--- a/Examples/CloudKitPlayground/CloudKitPlaygroundApp.swift
+++ b/Examples/CloudKitPlayground/CloudKitPlaygroundApp.swift
@@ -11,11 +11,8 @@ struct CloudKitPlaygroundApp: App {
     prepareDependencies {
       $0.defaultDatabase = try! appDatabase()
       $0.defaultSyncEngine = try! SyncEngine(
-        container: CKContainer(
-          identifier: "iCloud.co.pointfree.SQLiteData.demos.CloudKitPlayground"
-        ),
-        database: $0.defaultDatabase,
-        tables: [ModelA.self, ModelB.self, ModelC.self]
+        for: $0.defaultDatabase,
+        tables: ModelA.self, ModelB.self, ModelC.self
       )
     }
   }

--- a/Examples/CloudKitPlayground/Schema.swift
+++ b/Examples/CloudKitPlayground/Schema.swift
@@ -22,9 +22,7 @@ func appDatabase() throws -> any DatabaseWriter {
   let database: any DatabaseWriter
   var configuration = Configuration()
   configuration.prepareDatabase { db in
-    try db.attachMetadatabase(
-      containerIdentifier: "iCloud.co.pointfree.SQLiteData.demos.CloudKitPlayground"
-    )
+    try db.attachMetadatabase()
     #if DEBUG
       db.trace(options: .profile) {
         if context == .live {

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "69853b99c9eb6c69968432d61f94ae83a716bf02937dd3eaea7567cdf3966f5d",
+  "originHash" : "cfa986227a2051ca83eae9c181301c75e9fcd30d8f199a7ee1c7b269b548e192",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -74,24 +74,6 @@
       }
     },
     {
-      "identity" : "swift-docc-plugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
-      "state" : {
-        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
-        "version" : "1.4.5"
-      }
-    },
-    {
-      "identity" : "swift-docc-symbolkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
-      "state" : {
-        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "swift-identified-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
@@ -152,6 +134,15 @@
       "state" : {
         "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
         "version" : "601.0.1"
+      }
+    },
+    {
+      "identity" : "swift-tagged",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-tagged",
+      "state" : {
+        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
+        "version" : "0.10.0"
       }
     },
     {

--- a/Examples/Reminders/RemindersApp.swift
+++ b/Examples/Reminders/RemindersApp.swift
@@ -1,6 +1,7 @@
 import CloudKit
 import SharingGRDB
 import SwiftUI
+import UIKit
 
 @main
 struct RemindersApp: App {
@@ -13,17 +14,12 @@ struct RemindersApp: App {
       try! prepareDependencies {
         $0.defaultDatabase = try Reminders.appDatabase()
         $0.defaultSyncEngine = try SyncEngine(
-          container: CKContainer(
-            identifier: "iCloud.co.pointfree.SQLiteData.demos.field-timestamps-2.Reminders"
-          ),
-          database: $0.defaultDatabase,
-          tables: [
-            RemindersList.self,
-            RemindersListAsset.self,
-            Reminder.self,
-            Tag.self,
-            ReminderTag.self,
-          ]
+          for: $0.defaultDatabase,
+          tables: RemindersList.self,
+          RemindersListAsset.self,
+          Reminder.self,
+          Tag.self,
+          ReminderTag.self
         )
       }
     }
@@ -39,9 +35,6 @@ struct RemindersApp: App {
     }
   }
 }
-
-
-import UIKit
 
 class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
   func application(

--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -105,9 +105,7 @@ func appDatabase() throws -> any DatabaseWriter {
   let database: any DatabaseWriter
   var configuration = Configuration()
   configuration.prepareDatabase { db in
-    try db.attachMetadatabase(
-      containerIdentifier: "iCloud.co.pointfree.SQLiteData.demos.field-timestamps-2.Reminders"
-    )
+    try db.attachMetadatabase()
     #if DEBUG
       db.trace(options: .profile) {
         if context == .live {

--- a/README.md
+++ b/README.md
@@ -260,13 +260,8 @@ struct MyApp: App {
     prepareDependencies {
       $0.defaultDatabase = try! appDatabase()
       $0.defaultSyncEngine = SyncEngine(
-        container: CKContainer(
-          identifier: "iCloud.co.mycompany.MyApp"
-        ),
-        database: $0.defaultDatabase,
-        tables: [
-          Item.self,
-        ]
+        for: $0.defaultDatabase,
+        tables: Item.self
       )
     }
   }

--- a/Sources/SharingGRDBCore/CloudKit/DefaultSyncEngine.swift
+++ b/Sources/SharingGRDBCore/CloudKit/DefaultSyncEngine.swift
@@ -1,20 +1,20 @@
 #if canImport(CloudKit)
-import CloudKit
-import Dependencies
-import GRDB
+  import CloudKit
+  import Dependencies
+  import GRDB
 
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension DependencyValues {
-  public var defaultSyncEngine: SyncEngine {
-    get { self[SyncEngine.self] }
-    set { self[SyncEngine.self] = newValue }
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension DependencyValues {
+    public var defaultSyncEngine: SyncEngine {
+      get { self[SyncEngine.self] }
+      set { self[SyncEngine.self] = newValue }
+    }
   }
-}
 
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension SyncEngine: TestDependencyKey {
-  public static var testValue: SyncEngine {
-    try! SyncEngine(container: .default(), database: DatabaseQueue(), tables: [])
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension SyncEngine: TestDependencyKey {
+    public static var testValue: SyncEngine {
+      try! SyncEngine(for: DatabaseQueue())
+    }
   }
-}
 #endif

--- a/Sources/SharingGRDBCore/CloudKit/SyncEngine.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncEngine.swift
@@ -1512,7 +1512,7 @@
     /// func appDatabase() -> any DatabaseWriter {
     ///   var configuration = Configuration()
     ///   configuration.prepareDatabase = { db in
-    ///     db.attachMetadatabase(containerIdentifier: "iCloud.my.company.MyApp")
+    ///     db.attachMetadatabase()
     ///     …
     ///   }
     /// }
@@ -1523,7 +1523,19 @@
     /// - Parameter containerIdentifier: The identifier of the CloudKit container used to synchronize
     ///                                  data.
     public func attachMetadatabase(containerIdentifier: String? = nil) throws {
-      // TODO
+      let containerIdentifier = containerIdentifier
+        ?? ModelConfiguration(groupContainer: .automatic).cloudKitContainerIdentifier
+
+      guard let containerIdentifier else {
+        throw SyncEngine.SchemaError(
+          reason: .noCloudKitContainer,
+          debugDescription: """
+            No default CloudKit container found. Please add a container identifier to your app's \
+            entitlements.
+            """
+        )
+      }
+
       let databasePath = try SQLQueryExpression(
         """
         SELECT "file" FROM pragma_database_list()

--- a/Sources/SharingGRDBCore/Documentation.docc/Articles/CloudKit.md
+++ b/Sources/SharingGRDBCore/Documentation.docc/Articles/CloudKit.md
@@ -89,15 +89,11 @@ struct MyApp: App {
 ```
 
 The `SyncEngine` 
- [initializer](<doc:SyncEngine/init(container:defaultZone:database:logger:tables:privateTables:)>)
+[initializer](<doc:SyncEngine/init(for:tables:privateTables:containerIdentifier:defaultZone:logger:)>)
 has more options you may be interested in configuring.
 
-> Important: A few important things to note about this:
-> 
->   * The CloudKit container identifier must be explicitly provided and unfortunately cannot be 
->     extracted from Entitlements.plist automatically. That privilege is only afforded to SwiftData.
->   * You must explicitly provide all tables that you want to synchronize. We do this so that you
->     can have the option of having some local tables that are not synchronized to CloudKit.
+> Important: You must explicitly provide all tables that you want to synchronize. We do this so that
+> you can have the option of having some local tables that are not synchronized to CloudKit.
 
 Once this work is done the app should work exactly as it did before, but now any changes made
 to the database will be synchronized to CloudKit. You will still interact with your local SQLite

--- a/Sources/SharingGRDBCore/Documentation.docc/Articles/CloudKit.md
+++ b/Sources/SharingGRDBCore/Documentation.docc/Articles/CloudKit.md
@@ -108,7 +108,7 @@ you can use the `prepareDatabase` method on `Configuration` to attach the metada
 func appDatabase() -> any DatabaseWriter {
   var configuration = Configuration()
   configuration.prepareDatabase = { db in
-    db.attachMetadatabase(containerIdentifier: "iCloud.my.company.MyApp")
+    db.attachMetadatabase()
     …
   }
 }

--- a/Sources/SharingGRDBCore/Documentation.docc/Articles/CloudKitSharing.md
+++ b/Sources/SharingGRDBCore/Documentation.docc/Articles/CloudKitSharing.md
@@ -391,17 +391,9 @@ struct MyApp: App {
     try! prepareDependencies {
       $0.defaultDatabase = try appDatabase()
       $0.defaultSyncEngine = try SyncEngine(
-        container: CKContainer(
-          identifier: "iCloud.co.pointfree.sharing-grdb.Reminders"
-        ),
         database: $0.defaultDatabase,
-        tables: [
-          RemindersList.self,
-          Reminder.self,
-        ],
-        privateTables: [
-          RemindersListPrivate.self
-        ]
+        tables: RemindersList.self, Reminder.self,
+        privateTables: RemindersListPrivate.self
       )
     }
   }

--- a/Sources/SharingGRDBCore/Documentation.docc/Articles/CloudKitSharing.md
+++ b/Sources/SharingGRDBCore/Documentation.docc/Articles/CloudKitSharing.md
@@ -391,7 +391,7 @@ struct MyApp: App {
     try! prepareDependencies {
       $0.defaultDatabase = try appDatabase()
       $0.defaultSyncEngine = try SyncEngine(
-        database: $0.defaultDatabase,
+        for: $0.defaultDatabase,
         tables: RemindersList.self, Reminder.self,
         privateTables: RemindersListPrivate.self
       )

--- a/Sources/SharingGRDBCore/Documentation.docc/Articles/ComparisonWithSwiftData.md
+++ b/Sources/SharingGRDBCore/Documentation.docc/Articles/ComparisonWithSwiftData.md
@@ -797,14 +797,8 @@ inspect the Entitlements.plist in order to automatically extract that informatio
         try! prepareDependencies {
           $0.defaultDatabase = try appDatabase()
           $0.defaultSyncEngine = try SyncEngine(
-            container: CKContainer(
-              identifier: "iCloud.co.pointfree.sharing-grdb.Reminders"
-            ),
-            database: $0.defaultDatabase,
-            tables: [
-              RemindersList.self,
-              Reminder.self,
-            ]
+            for: $0.defaultDatabase,
+            tables: RemindersList.self, Reminder.self
           )
         }
       }

--- a/Sources/SharingGRDBCore/Documentation.docc/SharingGRDBCore.md
+++ b/Sources/SharingGRDBCore/Documentation.docc/SharingGRDBCore.md
@@ -184,13 +184,8 @@ struct MyApp: App {
     prepareDependencies {
       $0.defaultDatabase = try! appDatabase()
       $0.defaultSyncEngine = SyncEngine(
-        container: CKContainer(
-          identifier: "iCloud.co.mycompany.MyApp"
-        ),
-        database: $0.defaultDatabase,
-        tables: [
-          /* ... */
-        ]
+        for: $0.defaultDatabase,
+        tables: /* ... */
       )
     }
   }


### PR DESCRIPTION
- Infer default cloud container using SwiftData
- Statically require string identifier primary keyed tables

Before:
```swift
try SyncEngine(
  container: CKContainer(
    identifier: "iCloud.co.pointfree.Reminders"
  ),
  database: $0.defaultDatabase
  tables: [RemindersList.self, Reminder.self]
)
```

After:

```swift
try SyncEngine(
  for: $0.defaultDatabase
  tables: RemindersList.self, Reminder.self
)
```

Diff:

```diff
 try SyncEngine(
-  container: CKContainer(
-    identifier: "iCloud.co.pointfree.Reminders"
-  ),
-  database: $0.defaultDatabase
+  for: $0.defaultDatabase
-  tables: [RemindersList.self, Reminder.self]
+  tables: RemindersList.self, Reminder.self
 )
```