### PR TITLE
Add uniqueness to tag titles.

### DIFF
--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "05461ecd2d6ddd848b677fd572ee263adc87ab3aebd38d91f3f4c49ddaf3cdde",
+  "originHash" : "80ce8831f89d2da19d6c4e6f30a71328a79a080602e0d57e255665812e2823d7",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "branch" : "main",
-        "revision" : "2d9f1d94f5cbfbd37c5ab0b2500b385db95516a3"
+        "revision" : "2468f4e34d909d11c053d773562c03ffea40a72e",
+        "version" : "0.12.1"
       }
     },
     {

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "045453ad987825e0124358340f9eb671db13456ca8713bb035043d7c4e34e24b",
+  "originHash" : "05461ecd2d6ddd848b677fd572ee263adc87ab3aebd38d91f3f4c49ddaf3cdde",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -71,6 +71,24 @@
       "state" : {
         "revision" : "4c90d6b2b9bf0911af87b103bb40f41771891596",
         "version" : "1.9.2"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Examples/Reminders/ReminderForm.swift
+++ b/Examples/Reminders/ReminderForm.swift
@@ -135,7 +135,7 @@ struct ReminderFormView: View {
         selectedTags = try await database.read { db in
           try Tag
             .order(by: \.title)
-            .join(ReminderTag.all) { $0.title.eq($1.tag) }
+            .join(ReminderTag.all) { $0.primaryKey.eq($1.tagID) }
             .where { $1.reminderID.eq(reminderID) }
             .select { tag, _ in tag }
             .fetchAll(db)
@@ -179,7 +179,7 @@ struct ReminderFormView: View {
           .execute(db)
         try ReminderTag.insert {
           selectedTags.map { tag in
-            ReminderTag.Draft(reminderID: reminderID, tag: tag.title)
+            ReminderTag.Draft(reminderID: reminderID, tagID: tag.title)
           }
         }
         .execute(db)

--- a/Examples/Reminders/ReminderForm.swift
+++ b/Examples/Reminders/ReminderForm.swift
@@ -135,7 +135,7 @@ struct ReminderFormView: View {
         selectedTags = try await database.read { db in
           try Tag
             .order(by: \.title)
-            .join(ReminderTag.all) { $0.id.eq($1.tagID) }
+            .join(ReminderTag.all) { $0.title.eq($1.tag) }
             .where { $1.reminderID.eq(reminderID) }
             .select { tag, _ in tag }
             .fetchAll(db)
@@ -179,7 +179,7 @@ struct ReminderFormView: View {
           .execute(db)
         try ReminderTag.insert {
           selectedTags.map { tag in
-            ReminderTag.Draft(reminderID: reminderID, tagID: tag.id)
+            ReminderTag.Draft(reminderID: reminderID, tag: tag.title)
           }
         }
         .execute(db)

--- a/Examples/Reminders/RemindersDetail.swift
+++ b/Examples/Reminders/RemindersDetail.swift
@@ -103,7 +103,7 @@ class RemindersDetailModel: HashableObject {
         case .flagged: reminder.isFlagged
         case .remindersList(let list): reminder.remindersListID.eq(list.id)
         case .scheduled: reminder.isScheduled
-        case .tags(let tags): tag.title.ifnull("").in(tags.map(\.title))
+        case .tags(let tags): tag.primaryKey.ifnull("").in(tags.map(\.title))
         case .today: reminder.isToday
         }
       }

--- a/Examples/Reminders/RemindersDetail.swift
+++ b/Examples/Reminders/RemindersDetail.swift
@@ -103,7 +103,7 @@ class RemindersDetailModel: HashableObject {
         case .flagged: reminder.isFlagged
         case .remindersList(let list): reminder.remindersListID.eq(list.id)
         case .scheduled: reminder.isScheduled
-        case .tags(let tags): tag.primaryKey.ifnull("").in(tags.map(\.title))
+        case .tags(let tags): tag.title.ifnull("").in(tags.map(\.title))
         case .today: reminder.isToday
         }
       }

--- a/Examples/Reminders/RemindersDetail.swift
+++ b/Examples/Reminders/RemindersDetail.swift
@@ -103,7 +103,7 @@ class RemindersDetailModel: HashableObject {
         case .flagged: reminder.isFlagged
         case .remindersList(let list): reminder.remindersListID.eq(list.id)
         case .scheduled: reminder.isScheduled
-        case .tags(let tags): tag.id.ifnull(UUID(0)).in(tags.map(\.id))
+        case .tags(let tags): tag.title.ifnull("").in(tags.map(\.title))
         case .today: reminder.isToday
         }
       }
@@ -114,7 +114,7 @@ class RemindersDetailModel: HashableObject {
           remindersList: $3,
           isPastDue: $0.isPastDue,
           notes: $0.inlineNotes.substr(0, 200),
-          tags: #sql("\($2.jsonNames)")
+          tags: #sql("\($2.jsonTitles)")
         )
       }
   }

--- a/Examples/Reminders/RemindersLists.swift
+++ b/Examples/Reminders/RemindersLists.swift
@@ -124,10 +124,10 @@ class RemindersListsModel {
 
   func deleteTags(indexSet: IndexSet) {
     withErrorReporting {
-      let tagIDs = indexSet.map { tags[$0].id }
+      let tagTitles = indexSet.map { tags[$0].title }
       try database.write { db in
         try Tag
-          .where { $0.id.in(tagIDs) }
+          .where { $0.title.in(tagTitles) }
           .delete()
           .execute(db)
       }

--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -65,7 +65,7 @@ extension Reminder {
   }
   static let withTags = group(by: \.id)
     .leftJoin(ReminderTag.all) { $0.id.eq($1.reminderID) }
-    .leftJoin(Tag.all) { $1.tag.eq($2.title) }
+    .leftJoin(Tag.all) { $1.tagID.eq($2.primaryKey) }
 }
 
 extension Reminder.TableColumns {
@@ -87,7 +87,7 @@ extension Reminder.TableColumns {
 
 extension Tag {
   static let withReminders = group(by: \.title)
-    .leftJoin(ReminderTag.all) { $0.title.eq($1.tag) }
+    .leftJoin(ReminderTag.all) { $0.primaryKey.eq($1.tagID) }
     .leftJoin(Reminder.all) { $1.reminderID.eq($2.id) }
 }
 
@@ -101,7 +101,7 @@ extension Tag.TableColumns {
 struct ReminderTag: Hashable, Identifiable {
   let id: UUID
   var reminderID: Reminder.ID
-  var tag: Tag.ID
+  var tagID: Tag.ID
 }
 
 func appDatabase() throws -> any DatabaseWriter {
@@ -353,18 +353,18 @@ private let logger = Logger(subsystem: "Reminders", category: "Database")
         Tag(title: "social")
         Tag(title: "night")
         Tag(title: "adulting")
-        ReminderTag.Draft(reminderID: remindersIDs[0], tag: "someday")
-        ReminderTag.Draft(reminderID: remindersIDs[0], tag: "optional")
-        ReminderTag.Draft(reminderID: remindersIDs[0], tag: "adulting")
-        ReminderTag.Draft(reminderID: remindersIDs[1], tag: "someday")
-        ReminderTag.Draft(reminderID: remindersIDs[1], tag: "optional")
-        ReminderTag.Draft(reminderID: remindersIDs[2], tag: "adulting")
-        ReminderTag.Draft(reminderID: remindersIDs[3], tag: "car")
-        ReminderTag.Draft(reminderID: remindersIDs[3], tag: "kids")
-        ReminderTag.Draft(reminderID: remindersIDs[4], tag: "social")
-        ReminderTag.Draft(reminderID: remindersIDs[3], tag: "social")
-        ReminderTag.Draft(reminderID: remindersIDs[10], tag: "social")
-        ReminderTag.Draft(reminderID: remindersIDs[4], tag: "night")
+        ReminderTag.Draft(reminderID: remindersIDs[0], tagID: "someday")
+        ReminderTag.Draft(reminderID: remindersIDs[0], tagID: "optional")
+        ReminderTag.Draft(reminderID: remindersIDs[0], tagID: "adulting")
+        ReminderTag.Draft(reminderID: remindersIDs[1], tagID: "someday")
+        ReminderTag.Draft(reminderID: remindersIDs[1], tagID: "optional")
+        ReminderTag.Draft(reminderID: remindersIDs[2], tagID: "adulting")
+        ReminderTag.Draft(reminderID: remindersIDs[3], tagID: "car")
+        ReminderTag.Draft(reminderID: remindersIDs[3], tagID: "kids")
+        ReminderTag.Draft(reminderID: remindersIDs[4], tagID: "social")
+        ReminderTag.Draft(reminderID: remindersIDs[3], tagID: "social")
+        ReminderTag.Draft(reminderID: remindersIDs[10], tagID: "social")
+        ReminderTag.Draft(reminderID: remindersIDs[4], tagID: "night")
       }
     }
   }

--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -193,11 +193,8 @@ func appDatabase() throws -> any DatabaseWriter {
       """
       CREATE TABLE "remindersTags" (
         "id" TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT (uuid()),
-        "reminderID" TEXT NOT NULL,
-        "tagID" TEXT NOT NULL,
-
-        FOREIGN KEY("reminderID") REFERENCES "reminders"("id") ON DELETE CASCADE,
-        FOREIGN KEY("tag") REFERENCES "tags"("title") ON DELETE CASCADE ON UPDATE CASCADE
+        "reminderID" TEXT NOT NULL REFERENCES "reminders"("id") ON DELETE CASCADE,
+        "tagID" TEXT NOT NULL REFERENCES "tags"("title") ON DELETE CASCADE ON UPDATE CASCADE
       ) STRICT
       """
     )

--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -184,7 +184,7 @@ func appDatabase() throws -> any DatabaseWriter {
     try #sql(
       """
       CREATE TABLE "tags" (
-        "title" TEXT COLLATE NOCASE PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT ''
+        "title" TEXT COLLATE NOCASE PRIMARY KEY NOT NULL
       ) STRICT
       """
     )

--- a/Examples/Reminders/Schema.swift
+++ b/Examples/Reminders/Schema.swift
@@ -194,7 +194,7 @@ func appDatabase() throws -> any DatabaseWriter {
       CREATE TABLE "remindersTags" (
         "id" TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE DEFAULT (uuid()),
         "reminderID" TEXT NOT NULL,
-        "tag" TEXT NOT NULL,
+        "tagID" TEXT NOT NULL,
 
         FOREIGN KEY("reminderID") REFERENCES "reminders"("id") ON DELETE CASCADE,
         FOREIGN KEY("tag") REFERENCES "tags"("title") ON DELETE CASCADE ON UPDATE CASCADE

--- a/Examples/Reminders/SearchReminders.swift
+++ b/Examples/Reminders/SearchReminders.swift
@@ -67,7 +67,7 @@ class SearchRemindersModel {
               notes: $0.inlineNotes,
               reminder: $0,
               remindersList: $3,
-              tags: #sql("\($2.jsonNames)")
+              tags: #sql("\($2.jsonTitles)")
             )
           },
         animation: .default

--- a/Examples/Reminders/TagRow.swift
+++ b/Examples/Reminders/TagRow.swift
@@ -34,7 +34,7 @@ struct TagRow: View {
 #Preview {
   NavigationStack {
     List {
-      TagRow(tag: Tag(id: UUID(1), title: "optional"))
+      TagRow(tag: Tag(title: "optional"))
     }
   }
 }

--- a/Examples/Reminders/TagsForm.swift
+++ b/Examples/Reminders/TagsForm.swift
@@ -92,7 +92,6 @@ struct TagsView: View {
   func saveButtonTapped() {
     defer { tagTitle = "" }
     let tag = Tag(title: tagTitle)
-    selectedTags.append(tag)
     withErrorReporting {
       try database.write { db in
         if let existingTagTitle = editingTag?.title {
@@ -106,6 +105,7 @@ struct TagsView: View {
           .execute(db)
         }
       }
+      selectedTags.append(tag)
     }
   }
 

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", from: "2.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-structured-queries", branch: "main"),
+    .package(url: "https://github.com/pointfreeco/swift-structured-queries", from: "0.7.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.5.0"),
   ],
   targets: [


### PR DESCRIPTION
Based on the discussion in #117 I have updated the reminders demo to show how one can enforce uniqueness of tag titles. This is done by making the title of the tag the primary key and using an "ON UPDATE CASCADE" foreign key so that if one edits a tag title it updates all rows pointing to that tag.

I have also updated the UI to make it possible to create, edit and delete tags.