### PR TITLE
Regenerate macro code for CloudKit tables.

### DIFF
--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "045453ad987825e0124358340f9eb671db13456ca8713bb035043d7c4e34e24b",
+  "originHash" : "05461ecd2d6ddd848b677fd572ee263adc87ab3aebd38d91f3f4c49ddaf3cdde",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -71,6 +71,24 @@
       "state" : {
         "revision" : "4c90d6b2b9bf0911af87b103bb40f41771891596",
         "version" : "1.9.2"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b65215507a456e8eb22717bbb2cbc48bd7cf35bae37178bf7fd94e4426160680",
+  "originHash" : "304d33f17363a8d91fc9762f429327f95ab8d8ea5577c2120d53772b7ac70814",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "branch" : "main",
-        "revision" : "a2a7c06f5b3c60811558bd9552fbbbd0cc027d91"
+        "branch" : "sendable-triggers",
+        "revision" : "c56fe85c2963d0beb22a9a8503a01989f4c0a866"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", from: "2.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-structured-queries", branch: "main"),
+    .package(url: "https://github.com/pointfreeco/swift-structured-queries", branch: "sendable-triggers"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.5.0"),
   ],
   targets: [

--- a/Sources/SharingGRDBCore/CloudKit/RecordType+MacroExpansion.swift
+++ b/Sources/SharingGRDBCore/CloudKit/RecordType+MacroExpansion.swift
@@ -2,8 +2,8 @@
   import StructuredQueriesCore
 
   extension RecordType {
-    public struct TableColumns: StructuredQueriesCore.TableDefinition, StructuredQueriesCore
-        .PrimaryKeyedTableDefinition
+    public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition,
+      StructuredQueriesCore.PrimaryKeyedTableDefinition
     {
       public typealias QueryValue = RecordType
       public let tableName = StructuredQueriesCore.TableColumn<QueryValue, String>(
@@ -36,7 +36,7 @@
       package let tableName: String?
       package let schema: String
       package let tableInfo: Set<TableInfo>
-      public struct TableColumns: StructuredQueriesCore.TableDefinition {
+      public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
         public typealias QueryValue = Draft
         public let tableName = StructuredQueriesCore.TableColumn<QueryValue, String?>(
           "tableName",
@@ -60,11 +60,15 @@
           "\(self.tableName), \(self.schema), \(self.tableInfo)"
         }
       }
-      public static let columns = TableColumns()
+      public nonisolated static var columns: TableColumns {
+        TableColumns()
+      }
 
-      public static let tableName = RecordType.tableName
+      public nonisolated static var tableName: String {
+        RecordType.tableName
+      }
 
-      public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+      public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
         self.tableName = try decoder.decode(String.self)
         let schema = try decoder.decode(String.self)
         let tableInfo = try decoder.decode(Set<TableInfo>.JSONRepresentation.self)
@@ -78,7 +82,7 @@
         self.tableInfo = tableInfo
       }
 
-      public init(_ other: RecordType) {
+      public nonisolated init(_ other: RecordType) {
         self.tableName = other.tableName
         self.schema = other.schema
         self.tableInfo = other.tableInfo
@@ -95,10 +99,16 @@
     }
   }
 
-  extension RecordType: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable {
-    public static let columns = TableColumns()
-    public static let tableName = "sqlitedata_icloud_recordTypes"
-    public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+  nonisolated extension RecordType: StructuredQueriesCore.Table, StructuredQueriesCore
+      .PrimaryKeyedTable
+  {
+    public nonisolated static var columns: TableColumns {
+      TableColumns()
+    }
+    public nonisolated static var tableName: String {
+      "sqlitedata_icloud_recordTypes"
+    }
+    public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
       let tableName = try decoder.decode(String.self)
       let schema = try decoder.decode(String.self)
       let tableInfo = try decoder.decode(Set<TableInfo>.JSONRepresentation.self)

--- a/Sources/SharingGRDBCore/CloudKit/StateSerialization+MacroExpansion.swift
+++ b/Sources/SharingGRDBCore/CloudKit/StateSerialization+MacroExpansion.swift
@@ -4,11 +4,19 @@
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension StateSerialization {
-    public struct TableColumns: StructuredQueriesCore.TableDefinition, StructuredQueriesCore.PrimaryKeyedTableDefinition {
+    public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition,
+      StructuredQueriesCore.PrimaryKeyedTableDefinition
+    {
       public typealias QueryValue = StateSerialization
-      public let scope = StructuredQueriesCore.TableColumn<QueryValue, CKDatabase.Scope.RawValueRepresentation>("scope", keyPath: \QueryValue.scope)
-      public let data = StructuredQueriesCore.TableColumn<QueryValue, CKSyncEngine.State.Serialization.JSONRepresentation>("data", keyPath: \QueryValue.data)
-      public var primaryKey: StructuredQueriesCore.TableColumn<QueryValue, CKDatabase.Scope.RawValueRepresentation> {
+      public let scope = StructuredQueriesCore.TableColumn<
+        QueryValue, CKDatabase.Scope.RawValueRepresentation
+      >("scope", keyPath: \QueryValue.scope)
+      public let data = StructuredQueriesCore.TableColumn<
+        QueryValue, CKSyncEngine.State.Serialization.JSONRepresentation
+      >("data", keyPath: \QueryValue.data)
+      public var primaryKey:
+        StructuredQueriesCore.TableColumn<QueryValue, CKDatabase.Scope.RawValueRepresentation>
+      {
         self.scope
       }
       public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
@@ -26,25 +34,34 @@
       public typealias PrimaryTable = StateSerialization
       package var scope: CKDatabase.Scope?
       package var data: CKSyncEngine.State.Serialization
-      public struct TableColumns: StructuredQueriesCore.TableDefinition {
+      public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
         public typealias QueryValue = Draft
-        public let scope = StructuredQueriesCore.TableColumn<QueryValue, CKDatabase.Scope.RawValueRepresentation?>("scope", keyPath: \QueryValue.scope)
-        public let data = StructuredQueriesCore.TableColumn<QueryValue, CKSyncEngine.State.Serialization.JSONRepresentation>("data", keyPath: \QueryValue.data)
+        public let scope = StructuredQueriesCore.TableColumn<
+          QueryValue, CKDatabase.Scope.RawValueRepresentation?
+        >("scope", keyPath: \QueryValue.scope)
+        public let data = StructuredQueriesCore.TableColumn<
+          QueryValue, CKSyncEngine.State.Serialization.JSONRepresentation
+        >("data", keyPath: \QueryValue.data)
         public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
           [QueryValue.columns.scope, QueryValue.columns.data]
         }
-        public static var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression] {
+        public static var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression]
+        {
           [QueryValue.columns.scope, QueryValue.columns.data]
         }
         public var queryFragment: QueryFragment {
           "\(self.scope), \(self.data)"
         }
       }
-      public static let columns = TableColumns()
+      public nonisolated static var columns: TableColumns {
+        TableColumns()
+      }
 
-      public static let tableName = StateSerialization.tableName
+      public nonisolated static var tableName: String {
+        StateSerialization.tableName
+      }
 
-      public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+      public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
         self.scope = try decoder.decode(CKDatabase.Scope.RawValueRepresentation.self)
         let data = try decoder.decode(CKSyncEngine.State.Serialization.JSONRepresentation.self)
         guard let data else {
@@ -53,7 +70,7 @@
         self.data = data
       }
 
-      public init(_ other: StateSerialization) {
+      public nonisolated init(_ other: StateSerialization) {
         self.scope = other.scope
         self.data = other.data
       }
@@ -67,10 +84,17 @@
     }
   }
 
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) extension StateSerialization: StructuredQueriesCore.Table, StructuredQueriesCore.PrimaryKeyedTable {
-    public static let columns = TableColumns()
-    public static let tableName = "sqlitedata_icloud_stateSerialization"
-    public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  nonisolated extension StateSerialization: StructuredQueriesCore.Table, StructuredQueriesCore
+      .PrimaryKeyedTable
+  {
+    public nonisolated static var columns: TableColumns {
+      TableColumns()
+    }
+    public nonisolated static var tableName: String {
+      "sqlitedata_icloud_stateSerialization"
+    }
+    public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
       let scope = try decoder.decode(CKDatabase.Scope.RawValueRepresentation.self)
       let data = try decoder.decode(CKSyncEngine.State.Serialization.JSONRepresentation.self)
       guard let scope else {

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata+MacroExpansion.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata+MacroExpansion.swift
@@ -3,7 +3,7 @@
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension SyncMetadata {
-    public struct TableColumns: StructuredQueriesCore.TableDefinition {
+    public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
       public typealias QueryValue = SyncMetadata
       public let recordPrimaryKey = StructuredQueriesCore.TableColumn<QueryValue, String>(
         "recordPrimaryKey",
@@ -36,8 +36,8 @@
       public let lastKnownServerRecord = StructuredQueriesCore.TableColumn<
         QueryValue, CKRecord?.SystemFieldsRepresentation
       >("lastKnownServerRecord", keyPath: \QueryValue.lastKnownServerRecord)
-      package let _lastKnownServerRecordAllFields = StructuredQueriesCore.TableColumn<
-        QueryValue, CKRecord?.AllFieldsRepresentation
+      public let _lastKnownServerRecordAllFields = StructuredQueriesCore.TableColumn<
+        QueryValue, CKRecord?.SystemFieldsRepresentation
       >("_lastKnownServerRecordAllFields", keyPath: \QueryValue._lastKnownServerRecordAllFields)
       public let share = StructuredQueriesCore.TableColumn<
         QueryValue, CKShare?.SystemFieldsRepresentation
@@ -58,8 +58,7 @@
           QueryValue.columns.recordName, QueryValue.columns.parentRecordPrimaryKey,
           QueryValue.columns.parentRecordType, QueryValue.columns.parentRecordName,
           QueryValue.columns.lastKnownServerRecord,
-          QueryValue.columns._lastKnownServerRecordAllFields,
-          QueryValue.columns.share,
+          QueryValue.columns._lastKnownServerRecordAllFields, QueryValue.columns.share,
           QueryValue.columns.isShared, QueryValue.columns.userModificationDate,
         ]
       }
@@ -68,8 +67,7 @@
           QueryValue.columns.recordPrimaryKey, QueryValue.columns.recordType,
           QueryValue.columns.parentRecordPrimaryKey, QueryValue.columns.parentRecordType,
           QueryValue.columns.lastKnownServerRecord,
-          QueryValue.columns._lastKnownServerRecordAllFields,
-          QueryValue.columns.share,
+          QueryValue.columns._lastKnownServerRecordAllFields, QueryValue.columns.share,
           QueryValue.columns.userModificationDate,
         ]
       }
@@ -80,10 +78,14 @@
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  extension SyncMetadata: StructuredQueriesCore.Table {
-    public static let columns = TableColumns()
-    public static let tableName = "sqlitedata_icloud_metadata"
-    public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+  nonisolated extension SyncMetadata: StructuredQueriesCore.Table {
+    public nonisolated static var columns: TableColumns {
+      TableColumns()
+    }
+    public nonisolated static var tableName: String {
+      "sqlitedata_icloud_metadata"
+    }
+    public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
       let recordPrimaryKey = try decoder.decode(String.self)
       let recordType = try decoder.decode(String.self)
       let recordName = try decoder.decode(String.self)
@@ -92,7 +94,7 @@
       self.parentRecordName = try decoder.decode(String.self)
       let lastKnownServerRecord = try decoder.decode(CKRecord?.SystemFieldsRepresentation.self)
       let _lastKnownServerRecordAllFields = try decoder.decode(
-        CKRecord?.AllFieldsRepresentation.self
+        CKRecord?.SystemFieldsRepresentation.self
       )
       let share = try decoder.decode(CKShare?.SystemFieldsRepresentation.self)
       let isShared = try decoder.decode(Bool.self)
@@ -133,9 +135,9 @@
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  extension SyncMetadata.AncestorMetadata {
+  extension AncestorMetadata {
     public struct Columns: StructuredQueriesCore.QueryExpression {
-      public typealias QueryValue = SyncMetadata.AncestorMetadata
+      public typealias QueryValue = AncestorMetadata
       public let queryFragment: StructuredQueriesCore.QueryFragment
       public init(
         recordName: some StructuredQueriesCore.QueryExpression<String>,
@@ -150,8 +152,8 @@
       }
     }
 
-    public struct TableColumns: StructuredQueriesCore.TableDefinition {
-      public typealias QueryValue = SyncMetadata.AncestorMetadata
+    public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
+      public typealias QueryValue = AncestorMetadata
       public let recordName = StructuredQueriesCore.TableColumn<QueryValue, String>(
         "recordName",
         keyPath: \QueryValue.recordName
@@ -182,12 +184,24 @@
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  extension SyncMetadata.AncestorMetadata: StructuredQueriesCore.Table {
-    public static let columns = TableColumns()
-    public static let tableName = "ancestorMetadatas"
+  nonisolated extension AncestorMetadata: StructuredQueriesCore.Table, StructuredQueriesCore
+      .PartialSelectStatement
+  {
+    public typealias QueryValue = Self
+    public typealias From = Swift.Never
+    public nonisolated static var columns: TableColumns {
+      TableColumns()
+    }
+    public nonisolated static var tableName: String {
+      "ancestorMetadatas"
+    }
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension AncestorMetadata: StructuredQueriesCore.QueryRepresentable {
     public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
       let recordName = try decoder.decode(String.self)
-      self.parentRecordName = try decoder.decode(String.self)
+      let parentRecordName = try decoder.decode(String.self)
       let lastKnownServerRecord = try decoder.decode(CKRecord?.SystemFieldsRepresentation.self)
       guard let recordName else {
         throw QueryDecodingError.missingRequiredColumn
@@ -196,6 +210,7 @@
         throw QueryDecodingError.missingRequiredColumn
       }
       self.recordName = recordName
+      self.parentRecordName = parentRecordName
       self.lastKnownServerRecord = lastKnownServerRecord
     }
   }

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata+MacroExpansion.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata+MacroExpansion.swift
@@ -37,7 +37,7 @@
         QueryValue, CKRecord?.SystemFieldsRepresentation
       >("lastKnownServerRecord", keyPath: \QueryValue.lastKnownServerRecord)
       public let _lastKnownServerRecordAllFields = StructuredQueriesCore.TableColumn<
-        QueryValue, CKRecord?.SystemFieldsRepresentation
+        QueryValue, CKRecord?.AllFieldsRepresentation
       >("_lastKnownServerRecordAllFields", keyPath: \QueryValue._lastKnownServerRecordAllFields)
       public let share = StructuredQueriesCore.TableColumn<
         QueryValue, CKShare?.SystemFieldsRepresentation
@@ -94,7 +94,7 @@
       self.parentRecordName = try decoder.decode(String.self)
       let lastKnownServerRecord = try decoder.decode(CKRecord?.SystemFieldsRepresentation.self)
       let _lastKnownServerRecordAllFields = try decoder.decode(
-        CKRecord?.SystemFieldsRepresentation.self
+        CKRecord?.AllFieldsRepresentation.self
       )
       let share = try decoder.decode(CKShare?.SystemFieldsRepresentation.self)
       let isShared = try decoder.decode(Bool.self)

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
@@ -67,14 +67,14 @@
     public var userModificationDate: Date
   }
 
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-// @Selection @Table
-struct AncestorMetadata {
-  let recordName: String
-  let parentRecordName: String?
-  // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
-  let lastKnownServerRecord: CKRecord?
-}
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  // @Selection @Table
+  struct AncestorMetadata {
+    let recordName: String
+    let parentRecordName: String?
+    // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
+    let lastKnownServerRecord: CKRecord?
+  }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension SyncMetadata {

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
@@ -53,7 +53,7 @@
     public var lastKnownServerRecord: CKRecord?
 
     /// The last known `CKRecord` received from the server with all fields archived.
-    // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
+    // @Column(as: CKRecord?.AllFieldsRepresentation.self)
     package var _lastKnownServerRecordAllFields: CKRecord?
 
     /// The `CKShare` associated with this record, if it is shared.

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
@@ -68,7 +68,7 @@
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  // @Selection @Table
+  // @Table @Selection
   struct AncestorMetadata {
     let recordName: String
     let parentRecordName: String?

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
@@ -65,7 +65,19 @@
 
     /// The date the user last modified the record.
     public var userModificationDate: Date
+  }
 
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+// @Selection @Table
+struct AncestorMetadata {
+  let recordName: String
+  let parentRecordName: String?
+  // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
+  let lastKnownServerRecord: CKRecord?
+}
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension SyncMetadata {
     package init(
       recordPrimaryKey: String,
       recordType: String,
@@ -93,13 +105,6 @@
       self.userModificationDate = userModificationDate
     }
 
-    // @Selection @Table
-    struct AncestorMetadata {
-      let recordName: String
-      let parentRecordName: String?
-      // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
-      let lastKnownServerRecord: CKRecord?
-    }
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)

--- a/Sources/SharingGRDBCore/CloudKit/Triggers.swift
+++ b/Sources/SharingGRDBCore/CloudKit/Triggers.swift
@@ -163,22 +163,22 @@ private func rootServerRecord(
   With {
     SyncMetadata
       .where { $0.recordName.eq(recordName) }
-      .select { SyncMetadata.AncestorMetadata.Columns($0) }
+      .select { AncestorMetadata.Columns($0) }
       .union(
         all: true,
         SyncMetadata
-          .select { SyncMetadata.AncestorMetadata.Columns($0) }
-          .join(SyncMetadata.AncestorMetadata.all) { $0.recordName.is($1.parentRecordName) }
+          .select { AncestorMetadata.Columns($0) }
+          .join(AncestorMetadata.all) { $0.recordName.is($1.parentRecordName) }
       )
   } query: {
-    SyncMetadata.AncestorMetadata
+    AncestorMetadata
       .select(\.lastKnownServerRecord)
       .where { $0.parentRecordName.is(nil) }
   }
 }
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension SyncMetadata.AncestorMetadata.Columns {
+extension AncestorMetadata.Columns {
   fileprivate init(_ metadata: SyncMetadata.TableColumns) {
     self.init(
       recordName: metadata.recordName,

--- a/Sources/SharingGRDBCore/CloudKit/UnsyncedRecordID+MacroExpansion.swift
+++ b/Sources/SharingGRDBCore/CloudKit/UnsyncedRecordID+MacroExpansion.swift
@@ -1,11 +1,20 @@
 import StructuredQueriesCore
 
 extension UnsyncedRecordID {
-  public struct TableColumns: StructuredQueriesCore.TableDefinition {
+  public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
     public typealias QueryValue = UnsyncedRecordID
-    public let recordName = StructuredQueriesCore.TableColumn<QueryValue, String>("recordName", keyPath: \QueryValue.recordName)
-    public let zoneName = StructuredQueriesCore.TableColumn<QueryValue, String>("zoneName", keyPath: \QueryValue.zoneName)
-    public let ownerName = StructuredQueriesCore.TableColumn<QueryValue, String>("ownerName", keyPath: \QueryValue.ownerName)
+    public let recordName = StructuredQueriesCore.TableColumn<QueryValue, String>(
+      "recordName",
+      keyPath: \QueryValue.recordName
+    )
+    public let zoneName = StructuredQueriesCore.TableColumn<QueryValue, String>(
+      "zoneName",
+      keyPath: \QueryValue.zoneName
+    )
+    public let ownerName = StructuredQueriesCore.TableColumn<QueryValue, String>(
+      "ownerName",
+      keyPath: \QueryValue.ownerName
+    )
     public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
       [QueryValue.columns.recordName, QueryValue.columns.zoneName, QueryValue.columns.ownerName]
     }
@@ -18,10 +27,14 @@ extension UnsyncedRecordID {
   }
 }
 
-extension UnsyncedRecordID: StructuredQueriesCore.Table {
-  public static let columns = TableColumns()
-  public static let tableName = "sqlitedata_icloud_unsyncedRecordIDs"
-  public init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+nonisolated extension UnsyncedRecordID: StructuredQueriesCore.Table {
+  public nonisolated static var columns: TableColumns {
+    TableColumns()
+  }
+  public nonisolated static var tableName: String {
+    "sqlitedata_icloud_unsyncedRecordIDs"
+  }
+  public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
     let recordName = try decoder.decode(String.self)
     let zoneName = try decoder.decode(String.self)
     let ownerName = try decoder.decode(String.self)

--- a/Tests/SharingGRDBTests/CloudKitTests/AccountLifecycleTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/AccountLifecycleTests.swift
@@ -9,7 +9,7 @@ import Testing
 
 extension BaseCloudKitTests {
   @MainActor
-  final class AccountLifecycleTests: BaseCloudKitTests, Sendable {
+  final class AccountLifecycleTests: BaseCloudKitTests, @unchecked Sendable {
     @Test func signOutClearsUserDatabaseAndMetadatabase() async throws {
       try await userDatabase.userWrite { db in
         try db.seed {

--- a/Tests/SharingGRDBTests/CloudKitTests/ReferenceViolationTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/ReferenceViolationTests.swift
@@ -180,7 +180,7 @@ extension BaseCloudKitTests {
           try RemindersList.find(1).delete().execute(db)
         }
       }
-      let modifications = try await withDependencies {
+      let modifications = try withDependencies {
         $0.date.now.addTimeInterval(2)
       } operation: {
         let reminderRecord = CKRecord(


### PR DESCRIPTION
The macros in StructuredQueries has changed a bit so regenerating their code for our CloudKit tables.