### PR TITLE
Handling more CloudKit sharing edge cases

### DIFF
--- a/Examples/Reminders/ReminderForm.swift
+++ b/Examples/Reminders/ReminderForm.swift
@@ -184,8 +184,8 @@ struct ReminderFormView: View {
         }
         .execute(db)
       }
+      dismiss()
     }
-    dismiss()
   }
 }
 

--- a/Sources/SharingGRDBCore/CloudKit/Metadatabase.swift
+++ b/Sources/SharingGRDBCore/CloudKit/Metadatabase.swift
@@ -63,7 +63,7 @@ func defaultMetadatabase(
         "share" BLOB,
         "isShared" INTEGER NOT NULL AS ("share" IS NOT NULL),
         "userModificationDate" TEXT NOT NULL DEFAULT (\(.datetime())),
-        "isDeleted" INTEGER NOT NULL DEFAULT 0,
+        "_isDeleted" INTEGER NOT NULL DEFAULT 0,
 
         PRIMARY KEY ("recordPrimaryKey", "recordType"),
         UNIQUE ("recordName")

--- a/Sources/SharingGRDBCore/CloudKit/Metadatabase.swift
+++ b/Sources/SharingGRDBCore/CloudKit/Metadatabase.swift
@@ -63,6 +63,7 @@ func defaultMetadatabase(
         "share" BLOB,
         "isShared" INTEGER NOT NULL AS ("share" IS NOT NULL),
         "userModificationDate" TEXT NOT NULL DEFAULT (\(.datetime())),
+        "isDeleted" INTEGER NOT NULL DEFAULT 0,
 
         PRIMARY KEY ("recordPrimaryKey", "recordType"),
         UNIQUE ("recordName")

--- a/Sources/SharingGRDBCore/CloudKit/SyncEngine.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncEngine.swift
@@ -633,7 +633,7 @@ extension SyncEngine: CKSyncEngineDelegate, SyncEngineDelegate {
           SyncMetadata
             .where { $0.parentRecordName.is(nil) && $0.recordName.in(deletedRecordNames) }
             .select {
-              RecordNameWithRootRecordName.Columns(
+              RecordWithRoot.Columns(
                 parentRecordName: $0.parentRecordName,
                 recordName: $0.recordName,
                 lastKnownServerRecord: $0.lastKnownServerRecord,
@@ -644,9 +644,9 @@ extension SyncEngine: CKSyncEngineDelegate, SyncEngineDelegate {
             .union(
               all: true,
               SyncMetadata
-                .join(RecordNameWithRootRecordName.all) { $1.recordName.is($0.parentRecordName) }
+                .join(RecordWithRoot.all) { $1.recordName.is($0.parentRecordName) }
                 .select { metadata, tree in
-                  RecordNameWithRootRecordName.Columns(
+                  RecordWithRoot.Columns(
                     parentRecordName: metadata.parentRecordName,
                     recordName: metadata.recordName,
                     lastKnownServerRecord: metadata.lastKnownServerRecord,
@@ -656,7 +656,7 @@ extension SyncEngine: CKSyncEngineDelegate, SyncEngineDelegate {
                 }
             )
         } query: {
-          RecordNameWithRootRecordName
+          RecordWithRoot
             .where { $0.recordName.in(deletedRecordNames) }
         }
         .fetchAll(db)

--- a/Sources/SharingGRDBCore/CloudKit/SyncEngine.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncEngine.swift
@@ -625,9 +625,7 @@ extension SyncEngine: CKSyncEngineDelegate, SyncEngineDelegate {
 
     let shareRecordIDsToDelete = metadataOfDeletions.compactMap(\.share?.recordID)
 
-    // TODO: short circuit this work if no shares are being deleted
-
-    let recordNamesWithRootRecordName = await withErrorReporting {
+    let recordsWithRoot = await withErrorReporting {
       try await userDatabase.read { db in
         try With {
           SyncMetadata
@@ -664,10 +662,10 @@ extension SyncEngine: CKSyncEngineDelegate, SyncEngineDelegate {
     }
     ?? []
 
-    for recordNameWithRootRecord in recordNamesWithRootRecordName {
+    for recordWithRoot in recordsWithRoot {
       guard
-        let lastKnownServerRecord = recordNameWithRootRecord.lastKnownServerRecord,
-        let rootLastKnownServerRecord = recordNameWithRootRecord.rootLastKnownServerRecord
+        let lastKnownServerRecord = recordWithRoot.lastKnownServerRecord,
+        let rootLastKnownServerRecord = recordWithRoot.rootLastKnownServerRecord
       else { continue }
       guard let rootShareRecordID = rootLastKnownServerRecord.share?.recordID
       else { continue }

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata+MacroExpansion.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata+MacroExpansion.swift
@@ -48,6 +48,12 @@
           keyPath: \QueryValue.isShared
         )
       }
+      public var isDeleted: StructuredQueriesCore.TableColumn<QueryValue, Bool> {
+        StructuredQueriesCore.TableColumn<QueryValue, Bool>(
+          "isDeleted",
+          keyPath: \QueryValue.isDeleted
+        )
+      }
       public let userModificationDate = StructuredQueriesCore.TableColumn<QueryValue, Date>(
         "userModificationDate",
         keyPath: \QueryValue.userModificationDate
@@ -59,7 +65,7 @@
           QueryValue.columns.parentRecordType, QueryValue.columns.parentRecordName,
           QueryValue.columns.lastKnownServerRecord,
           QueryValue.columns._lastKnownServerRecordAllFields, QueryValue.columns.share,
-          QueryValue.columns.isShared, QueryValue.columns.userModificationDate,
+          QueryValue.columns.isShared, QueryValue.columns.isDeleted, QueryValue.columns.userModificationDate,
         ]
       }
       public static var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression] {
@@ -68,11 +74,12 @@
           QueryValue.columns.parentRecordPrimaryKey, QueryValue.columns.parentRecordType,
           QueryValue.columns.lastKnownServerRecord,
           QueryValue.columns._lastKnownServerRecordAllFields, QueryValue.columns.share,
+          QueryValue.columns.isDeleted,
           QueryValue.columns.userModificationDate,
         ]
       }
       public var queryFragment: QueryFragment {
-        "\(self.recordPrimaryKey), \(self.recordType), \(self.recordName), \(self.parentRecordPrimaryKey), \(self.parentRecordType), \(self.parentRecordName), \(self.lastKnownServerRecord), \(self._lastKnownServerRecordAllFields), \(self.share), \(self.isShared), \(self.userModificationDate)"
+        "\(self.recordPrimaryKey), \(self.recordType), \(self.recordName), \(self.parentRecordPrimaryKey), \(self.parentRecordType), \(self.parentRecordName), \(self.lastKnownServerRecord), \(self._lastKnownServerRecordAllFields), \(self.share), \(self.isShared), \(self.isDeleted), \(self.userModificationDate)"
       }
     }
   }
@@ -98,6 +105,7 @@
       )
       let share = try decoder.decode(CKShare?.SystemFieldsRepresentation.self)
       let isShared = try decoder.decode(Bool.self)
+      let isDeleted = try decoder.decode(Bool.self)
       let userModificationDate = try decoder.decode(Date.self)
       guard let recordPrimaryKey else {
         throw QueryDecodingError.missingRequiredColumn
@@ -120,6 +128,9 @@
       guard let isShared else {
         throw QueryDecodingError.missingRequiredColumn
       }
+      guard let isDeleted else {
+        throw QueryDecodingError.missingRequiredColumn
+      }
       guard let userModificationDate else {
         throw QueryDecodingError.missingRequiredColumn
       }
@@ -130,6 +141,7 @@
       self._lastKnownServerRecordAllFields = _lastKnownServerRecordAllFields
       self.share = share
       self.isShared = isShared
+      self.isDeleted = isDeleted
       self.userModificationDate = userModificationDate
     }
   }

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata+MacroExpansion.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata+MacroExpansion.swift
@@ -48,10 +48,10 @@
           keyPath: \QueryValue.isShared
         )
       }
-      public var isDeleted: StructuredQueriesCore.TableColumn<QueryValue, Bool> {
+      public var _isDeleted: StructuredQueriesCore.TableColumn<QueryValue, Bool> {
         StructuredQueriesCore.TableColumn<QueryValue, Bool>(
-          "isDeleted",
-          keyPath: \QueryValue.isDeleted
+          "_isDeleted",
+          keyPath: \QueryValue._isDeleted
         )
       }
       public let userModificationDate = StructuredQueriesCore.TableColumn<QueryValue, Date>(
@@ -65,7 +65,7 @@
           QueryValue.columns.parentRecordType, QueryValue.columns.parentRecordName,
           QueryValue.columns.lastKnownServerRecord,
           QueryValue.columns._lastKnownServerRecordAllFields, QueryValue.columns.share,
-          QueryValue.columns.isShared, QueryValue.columns.isDeleted,
+          QueryValue.columns.isShared, QueryValue.columns._isDeleted,
           QueryValue.columns.userModificationDate,
         ]
       }
@@ -75,12 +75,12 @@
           QueryValue.columns.parentRecordPrimaryKey, QueryValue.columns.parentRecordType,
           QueryValue.columns.lastKnownServerRecord,
           QueryValue.columns._lastKnownServerRecordAllFields, QueryValue.columns.share,
-          QueryValue.columns.isDeleted,
+          QueryValue.columns._isDeleted,
           QueryValue.columns.userModificationDate,
         ]
       }
       public var queryFragment: QueryFragment {
-        "\(self.recordPrimaryKey), \(self.recordType), \(self.recordName), \(self.parentRecordPrimaryKey), \(self.parentRecordType), \(self.parentRecordName), \(self.lastKnownServerRecord), \(self._lastKnownServerRecordAllFields), \(self.share), \(self.isShared), \(self.isDeleted), \(self.userModificationDate)"
+        "\(self.recordPrimaryKey), \(self.recordType), \(self.recordName), \(self.parentRecordPrimaryKey), \(self.parentRecordType), \(self.parentRecordName), \(self.lastKnownServerRecord), \(self._lastKnownServerRecordAllFields), \(self.share), \(self.isShared), \(self._isDeleted), \(self.userModificationDate)"
       }
     }
   }
@@ -106,7 +106,7 @@
       )
       let share = try decoder.decode(CKShare?.SystemFieldsRepresentation.self)
       let isShared = try decoder.decode(Bool.self)
-      let isDeleted = try decoder.decode(Bool.self)
+      let _isDeleted = try decoder.decode(Bool.self)
       let userModificationDate = try decoder.decode(Date.self)
       guard let recordPrimaryKey else {
         throw QueryDecodingError.missingRequiredColumn
@@ -129,7 +129,7 @@
       guard let isShared else {
         throw QueryDecodingError.missingRequiredColumn
       }
-      guard let isDeleted else {
+      guard let _isDeleted else {
         throw QueryDecodingError.missingRequiredColumn
       }
       guard let userModificationDate else {
@@ -142,7 +142,7 @@
       self._lastKnownServerRecordAllFields = _lastKnownServerRecordAllFields
       self.share = share
       self.isShared = isShared
-      self.isDeleted = isDeleted
+      self._isDeleted = _isDeleted
       self.userModificationDate = userModificationDate
     }
   }
@@ -229,34 +229,59 @@
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  extension RecordNameWithRootRecordName {
+  extension RecordWithRoot {
     public struct Columns: StructuredQueriesCore.QueryExpression {
-      public typealias QueryValue = RecordNameWithRootRecordName
+      public typealias QueryValue = RecordWithRoot
       public let queryFragment: StructuredQueriesCore.QueryFragment
       public init(
         parentRecordName: some StructuredQueriesCore.QueryExpression<String?>,
         recordName: some StructuredQueriesCore.QueryExpression<String>,
-        lastKnownServerRecord: some StructuredQueriesCore.QueryExpression<CKRecord?.SystemFieldsRepresentation>,
+        lastKnownServerRecord: some StructuredQueriesCore.QueryExpression<
+          CKRecord?.SystemFieldsRepresentation
+        >,
         rootRecordName: some StructuredQueriesCore.QueryExpression<String>,
-        rootLastKnownServerRecord: some StructuredQueriesCore.QueryExpression<CKRecord?.SystemFieldsRepresentation>
+        rootLastKnownServerRecord: some StructuredQueriesCore.QueryExpression<
+          CKRecord?.SystemFieldsRepresentation
+        >
       ) {
         self.queryFragment = """
-        \(parentRecordName.queryFragment) AS "parentRecordName", \(recordName.queryFragment) AS "recordName", \(lastKnownServerRecord.queryFragment) AS "lastKnownServerRecord", \(rootRecordName.queryFragment) AS "rootRecordName", \(rootLastKnownServerRecord.queryFragment) AS "rootLastKnownServerRecord"
-        """
+          \(parentRecordName.queryFragment) AS "parentRecordName", \(recordName.queryFragment) AS "recordName", \(lastKnownServerRecord.queryFragment) AS "lastKnownServerRecord", \(rootRecordName.queryFragment) AS "rootRecordName", \(rootLastKnownServerRecord.queryFragment) AS "rootLastKnownServerRecord"
+          """
       }
     }
     public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
-      public typealias QueryValue = RecordNameWithRootRecordName
-      public let parentRecordName = StructuredQueriesCore.TableColumn<QueryValue, String?>("parentRecordName", keyPath: \QueryValue.parentRecordName)
-      public let recordName = StructuredQueriesCore.TableColumn<QueryValue, String>("recordName", keyPath: \QueryValue.recordName)
-      public let lastKnownServerRecord = StructuredQueriesCore.TableColumn<QueryValue, CKRecord?.SystemFieldsRepresentation>("lastKnownServerRecord", keyPath: \QueryValue.lastKnownServerRecord)
-      public let rootRecordName = StructuredQueriesCore.TableColumn<QueryValue, String>("rootRecordName", keyPath: \QueryValue.rootRecordName)
-      public let rootLastKnownServerRecord = StructuredQueriesCore.TableColumn<QueryValue, CKRecord?.SystemFieldsRepresentation>("rootLastKnownServerRecord", keyPath: \QueryValue.rootLastKnownServerRecord)
+      public typealias QueryValue = RecordWithRoot
+      public let parentRecordName = StructuredQueriesCore.TableColumn<QueryValue, String?>(
+        "parentRecordName",
+        keyPath: \QueryValue.parentRecordName
+      )
+      public let recordName = StructuredQueriesCore.TableColumn<QueryValue, String>(
+        "recordName",
+        keyPath: \QueryValue.recordName
+      )
+      public let lastKnownServerRecord = StructuredQueriesCore.TableColumn<
+        QueryValue, CKRecord?.SystemFieldsRepresentation
+      >("lastKnownServerRecord", keyPath: \QueryValue.lastKnownServerRecord)
+      public let rootRecordName = StructuredQueriesCore.TableColumn<QueryValue, String>(
+        "rootRecordName",
+        keyPath: \QueryValue.rootRecordName
+      )
+      public let rootLastKnownServerRecord = StructuredQueriesCore.TableColumn<
+        QueryValue, CKRecord?.SystemFieldsRepresentation
+      >("rootLastKnownServerRecord", keyPath: \QueryValue.rootLastKnownServerRecord)
       public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
-        [QueryValue.columns.parentRecordName, QueryValue.columns.recordName, QueryValue.columns.lastKnownServerRecord, QueryValue.columns.rootRecordName, QueryValue.columns.rootLastKnownServerRecord]
+        [
+          QueryValue.columns.parentRecordName, QueryValue.columns.recordName,
+          QueryValue.columns.lastKnownServerRecord, QueryValue.columns.rootRecordName,
+          QueryValue.columns.rootLastKnownServerRecord,
+        ]
       }
       public static var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression] {
-        [QueryValue.columns.parentRecordName, QueryValue.columns.recordName, QueryValue.columns.lastKnownServerRecord, QueryValue.columns.rootRecordName, QueryValue.columns.rootLastKnownServerRecord]
+        [
+          QueryValue.columns.parentRecordName, QueryValue.columns.recordName,
+          QueryValue.columns.lastKnownServerRecord, QueryValue.columns.rootRecordName,
+          QueryValue.columns.rootLastKnownServerRecord,
+        ]
       }
       public var queryFragment: QueryFragment {
         "\(self.parentRecordName), \(self.recordName), \(self.lastKnownServerRecord), \(self.rootRecordName), \(self.rootLastKnownServerRecord)"
@@ -264,86 +289,91 @@
     }
   }
 
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) nonisolated extension RecordNameWithRootRecordName: StructuredQueriesCore.Table {
-  public nonisolated static var columns: TableColumns {
-    TableColumns()
-  }
-  public nonisolated static var tableName: String {
-    "recordNameWithRootRecordNames"
-  }
-  public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-    self.parentRecordName = try decoder.decode(String.self)
-    let recordName = try decoder.decode(String.self)
-    let lastKnownServerRecord = try decoder.decode(CKRecord?.SystemFieldsRepresentation.self)
-    let rootRecordName = try decoder.decode(String.self)
-    let rootLastKnownServerRecord = try decoder.decode(CKRecord?.SystemFieldsRepresentation.self)
-    guard let recordName else {
-      throw QueryDecodingError.missingRequiredColumn
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  nonisolated extension RecordWithRoot: StructuredQueriesCore.Table {
+    public nonisolated static var columns: TableColumns {
+      TableColumns()
     }
-    guard let lastKnownServerRecord else {
-      throw QueryDecodingError.missingRequiredColumn
+    public nonisolated static var tableName: String {
+      "recordWithRoots"
     }
-    guard let rootRecordName else {
-      throw QueryDecodingError.missingRequiredColumn
-    }
-    guard let rootLastKnownServerRecord else {
-      throw QueryDecodingError.missingRequiredColumn
-    }
-    self.recordName = recordName
-    self.lastKnownServerRecord = lastKnownServerRecord
-    self.rootRecordName = rootRecordName
-    self.rootLastKnownServerRecord = rootLastKnownServerRecord
-  }
-}
-
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension RootShare {
-  public struct Columns: StructuredQueriesCore.QueryExpression {
-    public typealias QueryValue = RootShare
-    public let queryFragment: StructuredQueriesCore.QueryFragment
-    public init(
-      parentRecordName: some StructuredQueriesCore.QueryExpression<String?>,
-      share: some StructuredQueriesCore.QueryExpression<CKShare?.SystemFieldsRepresentation>
-    ) {
-      self.queryFragment = """
-        \(parentRecordName.queryFragment) AS "parentRecordName", \(share.queryFragment) AS "share"
-        """
+    public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+      self.parentRecordName = try decoder.decode(String.self)
+      let recordName = try decoder.decode(String.self)
+      let lastKnownServerRecord = try decoder.decode(CKRecord?.SystemFieldsRepresentation.self)
+      let rootRecordName = try decoder.decode(String.self)
+      let rootLastKnownServerRecord = try decoder.decode(CKRecord?.SystemFieldsRepresentation.self)
+      guard let recordName else {
+        throw QueryDecodingError.missingRequiredColumn
+      }
+      guard let lastKnownServerRecord else {
+        throw QueryDecodingError.missingRequiredColumn
+      }
+      guard let rootRecordName else {
+        throw QueryDecodingError.missingRequiredColumn
+      }
+      guard let rootLastKnownServerRecord else {
+        throw QueryDecodingError.missingRequiredColumn
+      }
+      self.recordName = recordName
+      self.lastKnownServerRecord = lastKnownServerRecord
+      self.rootRecordName = rootRecordName
+      self.rootLastKnownServerRecord = rootLastKnownServerRecord
     }
   }
 
-  public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
-    public typealias QueryValue = RootShare
-    public let parentRecordName = StructuredQueriesCore.TableColumn<QueryValue, String?>("parentRecordName", keyPath: \QueryValue.parentRecordName)
-    public let share = StructuredQueriesCore.TableColumn<QueryValue, CKShare?.SystemFieldsRepresentation>("share", keyPath: \QueryValue.share)
-    public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
-      [QueryValue.columns.parentRecordName, QueryValue.columns.share]
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension RootShare {
+    public struct Columns: StructuredQueriesCore.QueryExpression {
+      public typealias QueryValue = RootShare
+      public let queryFragment: StructuredQueriesCore.QueryFragment
+      public init(
+        parentRecordName: some StructuredQueriesCore.QueryExpression<String?>,
+        share: some StructuredQueriesCore.QueryExpression<CKShare?.SystemFieldsRepresentation>
+      ) {
+        self.queryFragment = """
+          \(parentRecordName.queryFragment) AS "parentRecordName", \(share.queryFragment) AS "share"
+          """
+      }
     }
-    public static var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression] {
-      [QueryValue.columns.parentRecordName, QueryValue.columns.share]
-    }
-    public var queryFragment: QueryFragment {
-      "\(self.parentRecordName), \(self.share)"
-    }
-  }
-}
 
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) nonisolated extension RootShare: StructuredQueriesCore.Table {
-  public nonisolated static var columns: TableColumns {
-    TableColumns()
-  }
-  public nonisolated static var tableName: String {
-    "rootShares"
-  }
-  public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
-    self.parentRecordName = try decoder.decode(String.self)
-    let share = try decoder.decode(CKShare?.SystemFieldsRepresentation.self)
-    guard let share else {
-      throw QueryDecodingError.missingRequiredColumn
+    public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
+      public typealias QueryValue = RootShare
+      public let parentRecordName = StructuredQueriesCore.TableColumn<QueryValue, String?>(
+        "parentRecordName",
+        keyPath: \QueryValue.parentRecordName
+      )
+      public let share = StructuredQueriesCore.TableColumn<
+        QueryValue, CKShare?.SystemFieldsRepresentation
+      >("share", keyPath: \QueryValue.share)
+      public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
+        [QueryValue.columns.parentRecordName, QueryValue.columns.share]
+      }
+      public static var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression] {
+        [QueryValue.columns.parentRecordName, QueryValue.columns.share]
+      }
+      public var queryFragment: QueryFragment {
+        "\(self.parentRecordName), \(self.share)"
+      }
     }
-    self.share = share
   }
-}
 
-
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  nonisolated extension RootShare: StructuredQueriesCore.Table {
+    public nonisolated static var columns: TableColumns {
+      TableColumns()
+    }
+    public nonisolated static var tableName: String {
+      "rootShares"
+    }
+    public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+      self.parentRecordName = try decoder.decode(String.self)
+      let share = try decoder.decode(CKShare?.SystemFieldsRepresentation.self)
+      guard let share else {
+        throw QueryDecodingError.missingRequiredColumn
+      }
+      self.share = share
+    }
+  }
 
 #endif

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata+MacroExpansion.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata+MacroExpansion.swift
@@ -296,5 +296,54 @@
   }
 }
 
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension RootShare {
+  public struct Columns: StructuredQueriesCore.QueryExpression {
+    public typealias QueryValue = RootShare
+    public let queryFragment: StructuredQueriesCore.QueryFragment
+    public init(
+      parentRecordName: some StructuredQueriesCore.QueryExpression<String?>,
+      share: some StructuredQueriesCore.QueryExpression<CKShare?.SystemFieldsRepresentation>
+    ) {
+      self.queryFragment = """
+        \(parentRecordName.queryFragment) AS "parentRecordName", \(share.queryFragment) AS "share"
+        """
+    }
+  }
+
+  public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
+    public typealias QueryValue = RootShare
+    public let parentRecordName = StructuredQueriesCore.TableColumn<QueryValue, String?>("parentRecordName", keyPath: \QueryValue.parentRecordName)
+    public let share = StructuredQueriesCore.TableColumn<QueryValue, CKShare?.SystemFieldsRepresentation>("share", keyPath: \QueryValue.share)
+    public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
+      [QueryValue.columns.parentRecordName, QueryValue.columns.share]
+    }
+    public static var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression] {
+      [QueryValue.columns.parentRecordName, QueryValue.columns.share]
+    }
+    public var queryFragment: QueryFragment {
+      "\(self.parentRecordName), \(self.share)"
+    }
+  }
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) nonisolated extension RootShare: StructuredQueriesCore.Table {
+  public nonisolated static var columns: TableColumns {
+    TableColumns()
+  }
+  public nonisolated static var tableName: String {
+    "rootShares"
+  }
+  public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+    self.parentRecordName = try decoder.decode(String.self)
+    let share = try decoder.decode(CKShare?.SystemFieldsRepresentation.self)
+    guard let share else {
+      throw QueryDecodingError.missingRequiredColumn
+    }
+    self.share = share
+  }
+}
+
+
 
 #endif

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata+MacroExpansion.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata+MacroExpansion.swift
@@ -65,7 +65,8 @@
           QueryValue.columns.parentRecordType, QueryValue.columns.parentRecordName,
           QueryValue.columns.lastKnownServerRecord,
           QueryValue.columns._lastKnownServerRecordAllFields, QueryValue.columns.share,
-          QueryValue.columns.isShared, QueryValue.columns.isDeleted, QueryValue.columns.userModificationDate,
+          QueryValue.columns.isShared, QueryValue.columns.isDeleted,
+          QueryValue.columns.userModificationDate,
         ]
       }
       public static var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression] {
@@ -226,4 +227,74 @@
       self.lastKnownServerRecord = lastKnownServerRecord
     }
   }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension RecordNameWithRootRecordName {
+    public struct Columns: StructuredQueriesCore.QueryExpression {
+      public typealias QueryValue = RecordNameWithRootRecordName
+      public let queryFragment: StructuredQueriesCore.QueryFragment
+      public init(
+        parentRecordName: some StructuredQueriesCore.QueryExpression<String?>,
+        recordName: some StructuredQueriesCore.QueryExpression<String>,
+        lastKnownServerRecord: some StructuredQueriesCore.QueryExpression<CKRecord?.SystemFieldsRepresentation>,
+        rootRecordName: some StructuredQueriesCore.QueryExpression<String>,
+        rootLastKnownServerRecord: some StructuredQueriesCore.QueryExpression<CKRecord?.SystemFieldsRepresentation>
+      ) {
+        self.queryFragment = """
+        \(parentRecordName.queryFragment) AS "parentRecordName", \(recordName.queryFragment) AS "recordName", \(lastKnownServerRecord.queryFragment) AS "lastKnownServerRecord", \(rootRecordName.queryFragment) AS "rootRecordName", \(rootLastKnownServerRecord.queryFragment) AS "rootLastKnownServerRecord"
+        """
+      }
+    }
+    public nonisolated struct TableColumns: StructuredQueriesCore.TableDefinition {
+      public typealias QueryValue = RecordNameWithRootRecordName
+      public let parentRecordName = StructuredQueriesCore.TableColumn<QueryValue, String?>("parentRecordName", keyPath: \QueryValue.parentRecordName)
+      public let recordName = StructuredQueriesCore.TableColumn<QueryValue, String>("recordName", keyPath: \QueryValue.recordName)
+      public let lastKnownServerRecord = StructuredQueriesCore.TableColumn<QueryValue, CKRecord?.SystemFieldsRepresentation>("lastKnownServerRecord", keyPath: \QueryValue.lastKnownServerRecord)
+      public let rootRecordName = StructuredQueriesCore.TableColumn<QueryValue, String>("rootRecordName", keyPath: \QueryValue.rootRecordName)
+      public let rootLastKnownServerRecord = StructuredQueriesCore.TableColumn<QueryValue, CKRecord?.SystemFieldsRepresentation>("rootLastKnownServerRecord", keyPath: \QueryValue.rootLastKnownServerRecord)
+      public static var allColumns: [any StructuredQueriesCore.TableColumnExpression] {
+        [QueryValue.columns.parentRecordName, QueryValue.columns.recordName, QueryValue.columns.lastKnownServerRecord, QueryValue.columns.rootRecordName, QueryValue.columns.rootLastKnownServerRecord]
+      }
+      public static var writableColumns: [any StructuredQueriesCore.WritableTableColumnExpression] {
+        [QueryValue.columns.parentRecordName, QueryValue.columns.recordName, QueryValue.columns.lastKnownServerRecord, QueryValue.columns.rootRecordName, QueryValue.columns.rootLastKnownServerRecord]
+      }
+      public var queryFragment: QueryFragment {
+        "\(self.parentRecordName), \(self.recordName), \(self.lastKnownServerRecord), \(self.rootRecordName), \(self.rootLastKnownServerRecord)"
+      }
+    }
+  }
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) nonisolated extension RecordNameWithRootRecordName: StructuredQueriesCore.Table {
+  public nonisolated static var columns: TableColumns {
+    TableColumns()
+  }
+  public nonisolated static var tableName: String {
+    "recordNameWithRootRecordNames"
+  }
+  public nonisolated init(decoder: inout some StructuredQueriesCore.QueryDecoder) throws {
+    self.parentRecordName = try decoder.decode(String.self)
+    let recordName = try decoder.decode(String.self)
+    let lastKnownServerRecord = try decoder.decode(CKRecord?.SystemFieldsRepresentation.self)
+    let rootRecordName = try decoder.decode(String.self)
+    let rootLastKnownServerRecord = try decoder.decode(CKRecord?.SystemFieldsRepresentation.self)
+    guard let recordName else {
+      throw QueryDecodingError.missingRequiredColumn
+    }
+    guard let lastKnownServerRecord else {
+      throw QueryDecodingError.missingRequiredColumn
+    }
+    guard let rootRecordName else {
+      throw QueryDecodingError.missingRequiredColumn
+    }
+    guard let rootLastKnownServerRecord else {
+      throw QueryDecodingError.missingRequiredColumn
+    }
+    self.recordName = recordName
+    self.lastKnownServerRecord = lastKnownServerRecord
+    self.rootRecordName = rootRecordName
+    self.rootLastKnownServerRecord = rootLastKnownServerRecord
+  }
+}
+
+
 #endif

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
@@ -69,14 +69,26 @@
     public var userModificationDate: Date
   }
 
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  // @Table @Selection
-  struct AncestorMetadata {
-    let recordName: String
-    let parentRecordName: String?
-    // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
-    let lastKnownServerRecord: CKRecord?
-  }
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+// @Table @Selection
+struct AncestorMetadata {
+  let recordName: String
+  let parentRecordName: String?
+  // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
+  let lastKnownServerRecord: CKRecord?
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+// @Table @Selection
+struct RecordNameWithRootRecordName {
+  let parentRecordName: String?
+  let recordName: String
+  // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
+  let lastKnownServerRecord: CKRecord?
+  let rootRecordName: String
+  // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
+  let rootLastKnownServerRecord: CKRecord?
+}
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension SyncMetadata {

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
@@ -60,6 +60,8 @@
     // @Column(as: CKShare?.SystemFieldsRepresentation.self)
     public var share: CKShare?
 
+    public var isDeleted = false
+
     // @Column(generated: .virtual)
     public let isShared: Bool
 

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
@@ -90,6 +90,14 @@ struct RecordNameWithRootRecordName {
   let rootLastKnownServerRecord: CKRecord?
 }
 
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+// @Table @Selection
+struct RootShare {
+  let parentRecordName: String?
+  // @Column(as: CKShare?.SystemFieldsRepresentation.self)
+  let share: CKShare?
+}
+
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension SyncMetadata {
     package init(

--- a/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
+++ b/Sources/SharingGRDBCore/CloudKit/SyncMetadata.swift
@@ -60,7 +60,9 @@
     // @Column(as: CKShare?.SystemFieldsRepresentation.self)
     public var share: CKShare?
 
-    public var isDeleted = false
+    /// Determines if the metadata has been "soft" deleted. It will be fully deleted once the
+    /// next batch of pending changes is processed.
+    public var _isDeleted = false
 
     // @Column(generated: .virtual)
     public let isShared: Bool
@@ -69,34 +71,34 @@
     public var userModificationDate: Date
   }
 
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-// @Table @Selection
-struct AncestorMetadata {
-  let recordName: String
-  let parentRecordName: String?
-  // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
-  let lastKnownServerRecord: CKRecord?
-}
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  // @Table @Selection
+  struct AncestorMetadata {
+    let recordName: String
+    let parentRecordName: String?
+    // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
+    let lastKnownServerRecord: CKRecord?
+  }
 
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-// @Table @Selection
-struct RecordNameWithRootRecordName {
-  let parentRecordName: String?
-  let recordName: String
-  // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
-  let lastKnownServerRecord: CKRecord?
-  let rootRecordName: String
-  // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
-  let rootLastKnownServerRecord: CKRecord?
-}
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  // @Table @Selection
+  struct RecordWithRoot {
+    let parentRecordName: String?
+    let recordName: String
+    // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
+    let lastKnownServerRecord: CKRecord?
+    let rootRecordName: String
+    // @Column(as: CKRecord?.SystemFieldsRepresentation.self)
+    let rootLastKnownServerRecord: CKRecord?
+  }
 
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-// @Table @Selection
-struct RootShare {
-  let parentRecordName: String?
-  // @Column(as: CKShare?.SystemFieldsRepresentation.self)
-  let share: CKShare?
-}
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  // @Table @Selection
+  struct RootShare {
+    let parentRecordName: String?
+    // @Column(as: CKShare?.SystemFieldsRepresentation.self)
+    let share: CKShare?
+  }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   extension SyncMetadata {

--- a/Sources/SharingGRDBCore/CloudKit/Triggers.swift
+++ b/Sources/SharingGRDBCore/CloudKit/Triggers.swift
@@ -46,7 +46,7 @@
               $0.recordPrimaryKey.eq(SQLQueryExpression("\(old.primaryKey)"))
                 && $0.recordType.eq(tableName)
             }
-            .update { $0.isDeleted = true }
+            .update { $0._isDeleted = true }
         } when: { _ in
           !SyncEngine.isSynchronizingChanges()
         }
@@ -128,14 +128,14 @@
       after: .update { _, new in
         Values(.didUpdate(new))
       } when: { old, new in
-        old.isDeleted.eq(new.isDeleted) && !SyncEngine.isSynchronizingChanges()
+        old._isDeleted.eq(new._isDeleted) && !SyncEngine.isSynchronizingChanges()
       }
     )
 
     fileprivate static let afterDeleteTrigger = createTemporaryTrigger(
       "after_delete_on_sqlitedata_icloud_metadata",
       ifNotExists: true,
-      after: .update(of: \.isDeleted) { _, new in
+      after: .update(of: \._isDeleted) { _, new in
         Values(
           .didDelete(
             recordName: new.recordName,
@@ -145,7 +145,7 @@
           )
         )
       } when: { old, new in
-        !old.isDeleted && new.isDeleted && !SyncEngine.isSynchronizingChanges()
+        !old._isDeleted && new._isDeleted && !SyncEngine.isSynchronizingChanges()
       }
     )
   }

--- a/Sources/SharingGRDBCore/CloudKit/Triggers.swift
+++ b/Sources/SharingGRDBCore/CloudKit/Triggers.swift
@@ -1,251 +1,269 @@
 #if canImport(CloudKit)
-import CloudKit
-import Foundation
+  import CloudKit
+  import Foundation
 
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension PrimaryKeyedTable {
-  static func metadataTriggers(parentForeignKey: ForeignKey?) -> [TemporaryTrigger<Self>] {
-    [
-      afterInsert(parentForeignKey: parentForeignKey),
-      afterUpdate(parentForeignKey: parentForeignKey),
-      afterDeleteFromUser,
-      afterDeleteFromSyncEngine,
-    ]
-  }
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension PrimaryKeyedTable {
+    static func metadataTriggers(parentForeignKey: ForeignKey?) -> [TemporaryTrigger<Self>] {
+      [
+        afterInsert(parentForeignKey: parentForeignKey),
+        afterUpdate(parentForeignKey: parentForeignKey),
+        afterDeleteFromUser(parentForeignKey: parentForeignKey),
+        afterDeleteFromSyncEngine,
+      ]
+    }
 
-  fileprivate static func afterInsert(parentForeignKey: ForeignKey?) -> TemporaryTrigger<Self> {
-    let (parentRecordPrimaryKey, parentRecordType): (QueryFragment, QueryFragment) =
-    parentForeignKey
-      .map { (#""new".\#(quote: $0.from)"#, "\(bind: $0.table)") }
-    ?? ("NULL", "NULL")
+    fileprivate static func afterInsert(parentForeignKey: ForeignKey?) -> TemporaryTrigger<Self> {
+      createTemporaryTrigger(
+        "\(String.sqliteDataCloudKitSchemaName)_after_insert_on_\(tableName)",
+        ifNotExists: true,
+        after: .insert { new in
+          checkWritePermissions(parentForeignKey: parentForeignKey)
+          SyncMetadata.upsert(new: new, parentForeignKey: parentForeignKey)
+        }
+      )
+    }
 
-    return createTemporaryTrigger(
-      "\(String.sqliteDataCloudKitSchemaName)_after_insert_on_\(tableName)",
-      ifNotExists: true,
-      after: .insert { new in
-        With {
+    fileprivate static func afterUpdate(parentForeignKey: ForeignKey?) -> TemporaryTrigger<Self> {
+      createTemporaryTrigger(
+        "\(String.sqliteDataCloudKitSchemaName)_after_update_on_\(tableName)",
+        ifNotExists: true,
+        after: .update { _, new in
+          checkWritePermissions(parentForeignKey: parentForeignKey)
+          SyncMetadata.upsert(new: new, parentForeignKey: parentForeignKey)
+        }
+      )
+    }
+
+    fileprivate static func afterDeleteFromUser(parentForeignKey: ForeignKey?) -> TemporaryTrigger<Self> {
+      createTemporaryTrigger(
+        "\(String.sqliteDataCloudKitSchemaName)_after_delete_on_\(tableName)_from_user",
+        ifNotExists: true,
+        after: .delete { old in
+          checkWritePermissions(parentForeignKey: parentForeignKey)
           SyncMetadata
             .where {
-              $0.recordPrimaryKey.is(SQLQueryExpression(parentRecordPrimaryKey))
-              && $0.recordType.is(SQLQueryExpression(parentRecordType))
+              $0.recordPrimaryKey.eq(SQLQueryExpression("\(old.primaryKey)"))
+                && $0.recordType.eq(tableName)
             }
-            .select { RootShare.Columns(parentRecordName: $0.parentRecordName, share: $0.share) }
-            .union(
-              all: true,
-              SyncMetadata
-                .select {
-                  RootShare.Columns(parentRecordName: $0.parentRecordName, share: $0.share)
-                }
-                .join(RootShare.all) { $0.recordName.is($1.parentRecordName) }
-            )
-        } query: {
-          RootShare
-            .select { _ in
-              SQLQueryExpression(
-                "RAISE(ABORT, \(quote: SyncEngine.writePermissionError, delimiter: .text))",
-                as: Never.self
-              )
-            }
-            .where {
-              $0.parentRecordName.is(nil)
-              && !SQLQueryExpression("\(raw: String.sqliteDataCloudKitSchemaName)_hasPermission(\($0.share))")
-            }
+            .update { $0.isDeleted = true }
+        } when: { _ in
+          !SyncEngine.isSynchronizingChanges()
         }
+      )
+    }
 
-        SyncMetadata.upsert(new: new, parentForeignKey: parentForeignKey)
+    fileprivate static var afterDeleteFromSyncEngine: TemporaryTrigger<Self> {
+      createTemporaryTrigger(
+        "\(String.sqliteDataCloudKitSchemaName)_after_delete_on_\(tableName)_from_sync_engine",
+        ifNotExists: true,
+        after: .delete { old in
+          SyncMetadata
+            .where {
+              $0.recordPrimaryKey.eq(SQLQueryExpression("\(old.primaryKey)"))
+                && $0.recordType.eq(tableName)
+            }
+            .delete()
+        } when: { _ in
+          SyncEngine.isSynchronizingChanges()
+        }
+      )
+    }
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension SyncMetadata {
+    fileprivate static func upsert<T: PrimaryKeyedTable>(
+      new: TemporaryTrigger<T>.Operation.New,
+      parentForeignKey: ForeignKey?,
+    ) -> some StructuredQueriesCore.Statement {
+      let (parentRecordPrimaryKey, parentRecordType): (QueryFragment, QueryFragment) =
+        parentForeignKey
+        .map { (#""new".\#(quote: $0.from)"#, "\(bind: $0.table)") }
+        ?? ("NULL", "NULL")
+      return insert {
+        ($0.recordPrimaryKey, $0.recordType, $0.parentRecordPrimaryKey, $0.parentRecordType)
+      } select: {
+        Values(
+          SQLQueryExpression("\(new.primaryKey)"),
+          T.tableName,
+          SQLQueryExpression(parentRecordPrimaryKey),
+          SQLQueryExpression(parentRecordType)
+        )
+      } onConflict: {
+        ($0.recordPrimaryKey, $0.recordType)
+      } doUpdate: {
+        $0.parentRecordPrimaryKey = $1.parentRecordPrimaryKey
+        $0.parentRecordType = $1.parentRecordType
+        $0.userModificationDate = $1.userModificationDate
       }
-    )
+    }
   }
 
-  fileprivate static func afterUpdate(parentForeignKey: ForeignKey?) -> TemporaryTrigger<Self> {
-    createTemporaryTrigger(
-      "\(String.sqliteDataCloudKitSchemaName)_after_update_on_\(tableName)",
-      ifNotExists: true,
-      after: .update { _, new in SyncMetadata.upsert(new: new, parentForeignKey: parentForeignKey) }
-    )
-  }
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension SyncMetadata {
+    static var callbackTriggers: [TemporaryTrigger<Self>] {
+      [
+        afterInsertTrigger,
+        afterUpdateTrigger,
+        afterDeleteTrigger,
+      ]
+    }
 
-  fileprivate static var afterDeleteFromUser: TemporaryTrigger<Self> {
-    createTemporaryTrigger(
-      "\(String.sqliteDataCloudKitSchemaName)_after_delete_on_\(tableName)_from_user",
+    private enum ParentSyncMetadata: AliasName {}
+
+    fileprivate static let afterInsertTrigger = createTemporaryTrigger(
+      "after_insert_on_sqlitedata_icloud_metadata",
       ifNotExists: true,
-      after: .delete { old in
-        SyncMetadata
-          .where {
-            $0.recordPrimaryKey.eq(SQLQueryExpression("\(old.primaryKey)"))
-            && $0.recordType.eq(tableName)
-          }
-          .update { $0.isDeleted = true }
+      after: .insert { new in
+        Values(.didUpdate(new))
       } when: { _ in
         !SyncEngine.isSynchronizingChanges()
       }
     )
-  }
 
-  fileprivate static var afterDeleteFromSyncEngine: TemporaryTrigger<Self> {
-    createTemporaryTrigger(
-      "\(String.sqliteDataCloudKitSchemaName)_after_delete_on_\(tableName)_from_sync_engine",
+    fileprivate static let afterUpdateTrigger = createTemporaryTrigger(
+      "after_update_on_sqlitedata_icloud_metadata",
       ifNotExists: true,
-      after: .delete { old in
-        SyncMetadata
-          .where {
-            $0.recordPrimaryKey.eq(SQLQueryExpression("\(old.primaryKey)"))
-            && $0.recordType.eq(tableName)
-          }
-          .delete()
-      } when: { _ in
-        SyncEngine.isSynchronizingChanges()
+      after: .update { _, new in
+        Values(.didUpdate(new))
+      } when: { old, new in
+        old.isDeleted.eq(new.isDeleted) && !SyncEngine.isSynchronizingChanges()
+      }
+    )
+
+    fileprivate static let afterDeleteTrigger = createTemporaryTrigger(
+      "after_delete_on_sqlitedata_icloud_metadata",
+      ifNotExists: true,
+      after: .update(of: \.isDeleted) { _, new in
+        Values(
+          .didDelete(
+            recordName: new.recordName,
+            lastKnownServerRecord: new.lastKnownServerRecord
+              ?? rootServerRecord(recordName: new.recordName),
+            share: new.share
+          )
+        )
+      } when: { old, new in
+        !old.isDeleted && new.isDeleted && !SyncEngine.isSynchronizingChanges()
       }
     )
   }
-}
 
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension SyncMetadata {
-  fileprivate static func upsert<T: PrimaryKeyedTable>(
-    new: TemporaryTrigger<T>.Operation.New,
-    parentForeignKey: ForeignKey?,
-  ) -> some StructuredQueriesCore.Statement {
+  extension QueryExpression where Self == SQLQueryExpression<()> {
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    fileprivate static func didUpdate(
+      _ new: StructuredQueriesCore.TableAlias<
+        SyncMetadata, TemporaryTrigger<SyncMetadata>.Operation._New
+      >
+        .TableColumns
+    ) -> Self {
+      .didUpdate(
+        recordName: new.recordName,
+        // TODO: separate lastKnownServerRecord from rootRecord
+        lastKnownServerRecord: new.lastKnownServerRecord
+          ?? rootServerRecord(recordName: new.recordName),
+        share: new.share
+      )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    private static func didUpdate(
+      recordName: some QueryExpression<String>,
+      lastKnownServerRecord: some QueryExpression<CKRecord.SystemFieldsRepresentation?>,
+      share: some QueryExpression<CKShare?.SystemFieldsRepresentation>
+    ) -> Self {
+      Self(
+        "\(raw: .sqliteDataCloudKitSchemaName)_didUpdate(\(recordName), \(lastKnownServerRecord), \(share))"
+      )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    fileprivate static func didDelete(
+      recordName: some QueryExpression<String>,
+      lastKnownServerRecord: some QueryExpression<CKRecord.SystemFieldsRepresentation?>,
+      share: some QueryExpression<CKShare?.SystemFieldsRepresentation>
+    ) -> Self {
+      Self(
+        "\(raw: .sqliteDataCloudKitSchemaName)_didDelete(\(recordName), \(lastKnownServerRecord), \(share))"
+      )
+    }
+  }
+
+  private func isUpdatingWithServerRecord() -> SQLQueryExpression<Bool> {
+    SQLQueryExpression("\(raw: .sqliteDataCloudKitSchemaName)_isUpdatingWithServerRecord()")
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  private func checkWritePermissions(
+    parentForeignKey: ForeignKey?
+  ) -> some StructuredQueriesCore.Statement<Never> {
     let (parentRecordPrimaryKey, parentRecordType): (QueryFragment, QueryFragment) =
       parentForeignKey
-        .map { (#""new".\#(quote: $0.from)"#, "\(bind: $0.table)") }
-        ?? ("NULL", "NULL")
-    return insert {
-      ($0.recordPrimaryKey, $0.recordType, $0.parentRecordPrimaryKey, $0.parentRecordType)
-    } select: {
-      Values(
-        SQLQueryExpression("\(new.primaryKey)"),
-        T.tableName,
-        SQLQueryExpression(parentRecordPrimaryKey),
-        SQLQueryExpression(parentRecordType)
+      .map { (#""new".\#(quote: $0.from)"#, "\(bind: $0.table)") }
+      ?? ("NULL", "NULL")
+
+    return With {
+      SyncMetadata
+        .where {
+          $0.recordPrimaryKey.is(SQLQueryExpression(parentRecordPrimaryKey))
+            && $0.recordType.is(SQLQueryExpression(parentRecordType))
+        }
+        .select { RootShare.Columns(parentRecordName: $0.parentRecordName, share: $0.share) }
+        .union(
+          all: true,
+          SyncMetadata
+            .select {
+              RootShare.Columns(parentRecordName: $0.parentRecordName, share: $0.share)
+            }
+            .join(RootShare.all) { $0.recordName.is($1.parentRecordName) }
+        )
+    } query: {
+      RootShare
+        .select { _ in
+          SQLQueryExpression(
+            "RAISE(ABORT, \(quote: SyncEngine.writePermissionError, delimiter: .text))",
+            as: Never.self
+          )
+        }
+        .where {
+          $0.parentRecordName.is(nil)
+            && !SQLQueryExpression(
+              "\(raw: String.sqliteDataCloudKitSchemaName)_hasPermission(\($0.share))"
+            )
+        }
+    }
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  private func rootServerRecord(
+    recordName: some QueryExpression<String>
+  ) -> some QueryExpression<CKRecord?.SystemFieldsRepresentation> {
+    With {
+      SyncMetadata
+        .where { $0.recordName.eq(recordName) }
+        .select { AncestorMetadata.Columns($0) }
+        .union(
+          all: true,
+          SyncMetadata
+            .select { AncestorMetadata.Columns($0) }
+            .join(AncestorMetadata.all) { $0.recordName.is($1.parentRecordName) }
+        )
+    } query: {
+      AncestorMetadata
+        .select(\.lastKnownServerRecord)
+        .where { $0.parentRecordName.is(nil) }
+    }
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  extension AncestorMetadata.Columns {
+    init(_ metadata: SyncMetadata.TableColumns) {
+      self.init(
+        recordName: metadata.recordName,
+        parentRecordName: metadata.parentRecordName,
+        lastKnownServerRecord: metadata.lastKnownServerRecord
       )
-    } onConflict: {
-      ($0.recordPrimaryKey, $0.recordType)
-    } doUpdate: {
-      $0.parentRecordPrimaryKey = $1.parentRecordPrimaryKey
-      $0.parentRecordType = $1.parentRecordType
-      $0.userModificationDate = $1.userModificationDate
     }
   }
-}
-
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension SyncMetadata {
-  static var callbackTriggers: [TemporaryTrigger<Self>] {
-    [
-      afterInsertTrigger,
-      afterUpdateTrigger,
-      afterDeleteTrigger,
-    ]
-  }
-
-  private enum ParentSyncMetadata: AliasName {}
-
-  fileprivate static let afterInsertTrigger = createTemporaryTrigger(
-    "after_insert_on_sqlitedata_icloud_metadata",
-    ifNotExists: true,
-    after: .insert { new in
-      Values(.didUpdate(new))
-    } when: { _ in
-      !SyncEngine.isSynchronizingChanges()
-    }
-  )
-
-  fileprivate static let afterUpdateTrigger = createTemporaryTrigger(
-    "after_update_on_sqlitedata_icloud_metadata",
-    ifNotExists: true,
-    after: .update { _, new in
-      Values(.didUpdate(new))
-    } when: { old, new in
-      old.isDeleted.eq(new.isDeleted) && !SyncEngine.isSynchronizingChanges()
-    }
-  )
-
-  fileprivate static let afterDeleteTrigger = createTemporaryTrigger(
-    "after_delete_on_sqlitedata_icloud_metadata",
-    ifNotExists: true,
-    after: .update(of: \.isDeleted) { _, new in
-      Values(.didDelete(
-        recordName: new.recordName,
-        lastKnownServerRecord: new.lastKnownServerRecord
-        ?? rootServerRecord(recordName: new.recordName),
-        share: new.share
-      ))
-    } when: { old, new in
-      !old.isDeleted && new.isDeleted && !SyncEngine.isSynchronizingChanges()
-    }
-  )
-}
-
-extension QueryExpression where Self == SQLQueryExpression<()> {
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  fileprivate static func didUpdate(
-    _ new: StructuredQueriesCore.TableAlias<
-      SyncMetadata, TemporaryTrigger<SyncMetadata>.Operation._New
-    >
-    .TableColumns
-  ) -> Self {
-    .didUpdate(
-      recordName: new.recordName,
-      // TODO: separate lastKnownServerRecord from rootRecord
-      lastKnownServerRecord: new.lastKnownServerRecord
-      ?? rootServerRecord(recordName: new.recordName),
-      share: new.share
-    )
-  }
-
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  private static func didUpdate(
-    recordName: some QueryExpression<String>,
-    lastKnownServerRecord: some QueryExpression<CKRecord.SystemFieldsRepresentation?>,
-    share: some QueryExpression<CKShare?.SystemFieldsRepresentation>
-  ) -> Self {
-    Self("\(raw: .sqliteDataCloudKitSchemaName)_didUpdate(\(recordName), \(lastKnownServerRecord), \(share))")
-  }
-
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  fileprivate static func didDelete(
-    recordName: some QueryExpression<String>,
-    lastKnownServerRecord: some QueryExpression<CKRecord.SystemFieldsRepresentation?>,
-    share: some QueryExpression<CKShare?.SystemFieldsRepresentation>
-  ) -> Self {
-    Self("\(raw: .sqliteDataCloudKitSchemaName)_didDelete(\(recordName), \(lastKnownServerRecord), \(share))")
-  }
-}
-
-private func isUpdatingWithServerRecord() -> SQLQueryExpression<Bool> {
-  SQLQueryExpression("\(raw: .sqliteDataCloudKitSchemaName)_isUpdatingWithServerRecord()")
-}
-
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-private func rootServerRecord(
-  recordName: some QueryExpression<String>
-) -> some QueryExpression<CKRecord?.SystemFieldsRepresentation> {
-  With {
-    SyncMetadata
-      .where { $0.recordName.eq(recordName) }
-      .select { AncestorMetadata.Columns($0) }
-      .union(
-        all: true,
-        SyncMetadata
-          .select { AncestorMetadata.Columns($0) }
-          .join(AncestorMetadata.all) { $0.recordName.is($1.parentRecordName) }
-      )
-  } query: {
-    AncestorMetadata
-      .select(\.lastKnownServerRecord)
-      .where { $0.parentRecordName.is(nil) }
-  }
-}
-
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-extension AncestorMetadata.Columns {
-  init(_ metadata: SyncMetadata.TableColumns) {
-    self.init(
-      recordName: metadata.recordName,
-      parentRecordName: metadata.parentRecordName,
-      lastKnownServerRecord: metadata.lastKnownServerRecord
-    )
-  }
-}
 #endif

--- a/Sources/SharingGRDBCore/CloudKit/Triggers.swift
+++ b/Sources/SharingGRDBCore/CloudKit/Triggers.swift
@@ -112,7 +112,8 @@ extension SyncMetadata {
       Values(.didDelete(
         recordName: old.recordName,
         lastKnownServerRecord: old.lastKnownServerRecord
-        ?? rootServerRecord(recordName: old.recordName)
+        ?? rootServerRecord(recordName: old.recordName),
+        share: old.share
       ))
     } when: { _ in
       !SyncEngine.isSynchronizingChanges()
@@ -131,24 +132,27 @@ extension QueryExpression where Self == SQLQueryExpression<()> {
     .didUpdate(
       recordName: new.recordName,
       lastKnownServerRecord: new.lastKnownServerRecord
-      ?? rootServerRecord(recordName: new.recordName)
+      ?? rootServerRecord(recordName: new.recordName),
+      share: new.share
     )
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   private static func didUpdate(
     recordName: some QueryExpression<String>,
-    lastKnownServerRecord: some QueryExpression<CKRecord.SystemFieldsRepresentation?>
+    lastKnownServerRecord: some QueryExpression<CKRecord.SystemFieldsRepresentation?>,
+    share: some QueryExpression<CKShare?.SystemFieldsRepresentation>
   ) -> Self {
-    Self("\(raw: .sqliteDataCloudKitSchemaName)_didUpdate(\(recordName), \(lastKnownServerRecord))")
+    Self("\(raw: .sqliteDataCloudKitSchemaName)_didUpdate(\(recordName), \(lastKnownServerRecord), \(share))")
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   fileprivate static func didDelete(
     recordName: some QueryExpression<String>,
-    lastKnownServerRecord: some QueryExpression<CKRecord.SystemFieldsRepresentation?>
+    lastKnownServerRecord: some QueryExpression<CKRecord.SystemFieldsRepresentation?>,
+    share: some QueryExpression<CKShare?.SystemFieldsRepresentation>
   ) -> Self {
-    Self("\(raw: .sqliteDataCloudKitSchemaName)_didDelete(\(recordName), \(lastKnownServerRecord))")
+    Self("\(raw: .sqliteDataCloudKitSchemaName)_didDelete(\(recordName), \(lastKnownServerRecord), \(share))")
   }
 }
 

--- a/Sources/SharingGRDBCore/CloudKit/Triggers.swift
+++ b/Sources/SharingGRDBCore/CloudKit/Triggers.swift
@@ -204,7 +204,7 @@ private func rootServerRecord(
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
 extension AncestorMetadata.Columns {
-  fileprivate init(_ metadata: SyncMetadata.TableColumns) {
+  init(_ metadata: SyncMetadata.TableColumns) {
     self.init(
       recordName: metadata.recordName,
       parentRecordName: metadata.parentRecordName,

--- a/Sources/SharingGRDBCore/CloudKit/Triggers.swift
+++ b/Sources/SharingGRDBCore/CloudKit/Triggers.swift
@@ -120,8 +120,8 @@ extension SyncMetadata {
     ifNotExists: true,
     after: .update { _, new in
       Values(.didUpdate(new))
-    } when: { _, _ in
-      !SyncEngine.isSynchronizingChanges()
+    } when: { old, new in
+      old.isDeleted.eq(new.isDeleted) && !SyncEngine.isSynchronizingChanges()
     }
   )
 
@@ -136,7 +136,7 @@ extension SyncMetadata {
         share: new.share
       ))
     } when: { old, new in
-      !old.isDeleted && new.isDeleted //&& !SyncEngine.isSynchronizingChanges()
+      !old.isDeleted && new.isDeleted && !SyncEngine.isSynchronizingChanges()
     }
   )
 }

--- a/Sources/SharingGRDBCore/CloudKit/Triggers.swift
+++ b/Sources/SharingGRDBCore/CloudKit/Triggers.swift
@@ -160,7 +160,6 @@
     ) -> Self {
       .didUpdate(
         recordName: new.recordName,
-        // TODO: separate lastKnownServerRecord from rootRecord
         lastKnownServerRecord: new.lastKnownServerRecord
           ?? rootServerRecord(recordName: new.recordName),
         share: new.share

--- a/Sources/SharingGRDBCore/Documentation.docc/Articles/CloudKitSharing.md
+++ b/Sources/SharingGRDBCore/Documentation.docc/Articles/CloudKitSharing.md
@@ -15,15 +15,7 @@ Info.plist with a value of `true`. This is subtly documented in [Apple's documen
 
 [Apple's documentation for sharing]: https://developer.apple.com/documentation/cloudkit/sharing-cloudkit-data-with-other-icloud-users#Create-and-Share-a-Topic
 
-- [Creating CKShare records](#Creating-CKShare-records)
-- [Accepting shared records](#Accepting-shared-records)
-- [Diving deeper into sharing](#Diving-deeper-into-sharing)
-  - [Sharing root records](#Sharing-root-records)
-  - [Sharing foreign key relationships](#Sharing-foreign-key-relationships)
-    - [One-to-many relationships](#One-to-many-relationships)
-    - [Many-to-many relationships](#Many-to-many-relationships)
-    - [One-to-"at most one" relationships](#One-to-at-most-one-relationships)
-- [Controlling what data is shared](#Controlling-what-data-is-shared)
+TODO: ToC
 
 ## Creating CKShare records
 
@@ -343,6 +335,10 @@ graph BT
 
 Here the `CoverImage` table has a foreign key pointing to the root table `RemindersList`, but since
 it is also the primary key of the table it enforces that at most one cover image belongs to a list.
+
+## Sharing permissions
+
+TODO: finish
 
 ## Controlling what data is shared
 

--- a/Tests/SharingGRDBTests/CloudKitTests/CloudKitTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/CloudKitTests.swift
@@ -557,7 +557,8 @@ extension BaseCloudKitTests {
           [0]: "sqlitedata_icloud_datetime",
           [1]: "sqlitedata_icloud_diddelete",
           [2]: "sqlitedata_icloud_didupdate",
-          [3]: "sqlitedata_icloud_syncengineissynchronizingchanges"
+          [3]: "sqlitedata_icloud_haspermission",
+          [4]: "sqlitedata_icloud_syncengineissynchronizingchanges"
         ]
         """
       }

--- a/Tests/SharingGRDBTests/CloudKitTests/ForeignKeyConstraintTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/ForeignKeyConstraintTests.swift
@@ -778,6 +778,40 @@ extension BaseCloudKitTests {
       }
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+        """
+        MockCloudContainer(
+          privateCloudDatabase: MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(3:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(3:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                share: nil,
+                id: 3,
+                isCompleted: 0,
+                remindersListID: 3,
+                title: "Schedule secret meeting"
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(3:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 3,
+                title: "Secret"
+              )
+            ]
+          ),
+          sharedCloudDatabase: MockCloudDatabase(
+            databaseScope: .shared,
+            storage: []
+          )
+        )
+        """
+      }
     }
   }
 }

--- a/Tests/SharingGRDBTests/CloudKitTests/NewTableSyncTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/NewTableSyncTests.swift
@@ -89,7 +89,7 @@ extension BaseCloudKitTests {
               title: "Write blog post"
             ),
             share: nil,
-            isDeleted: false,
+            _isDeleted: false,
             isShared: false,
             userModificationDate: Date(1970-01-01T00:00:00.000Z)
           ),
@@ -115,7 +115,7 @@ extension BaseCloudKitTests {
               title: "Personal"
             ),
             share: nil,
-            isDeleted: false,
+            _isDeleted: false,
             isShared: false,
             userModificationDate: Date(1970-01-01T00:00:00.000Z)
           )

--- a/Tests/SharingGRDBTests/CloudKitTests/NewTableSyncTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/NewTableSyncTests.swift
@@ -89,6 +89,7 @@ extension BaseCloudKitTests {
               title: "Write blog post"
             ),
             share: nil,
+            isDeleted: false,
             isShared: false,
             userModificationDate: Date(1970-01-01T00:00:00.000Z)
           ),
@@ -114,6 +115,7 @@ extension BaseCloudKitTests {
               title: "Personal"
             ),
             share: nil,
+            isDeleted: false,
             isShared: false,
             userModificationDate: Date(1970-01-01T00:00:00.000Z)
           )

--- a/Tests/SharingGRDBTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/SharingTests.swift
@@ -294,7 +294,7 @@ extension BaseCloudKitTests {
               title: "Personal"
             ),
             share: nil,
-            isDeleted: false,
+            _isDeleted: false,
             isShared: false,
             userModificationDate: Date(1970-01-01T00:00:00.000Z)
           )

--- a/Tests/SharingGRDBTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/SharingTests.swift
@@ -294,6 +294,7 @@ extension BaseCloudKitTests {
               title: "Personal"
             ),
             share: nil,
+            isDeleted: false,
             isShared: false,
             userModificationDate: Date(1970-01-01T00:00:00.000Z)
           )

--- a/Tests/SharingGRDBTests/CloudKitTests/TriggerTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/TriggerTests.swift
@@ -19,8 +19,8 @@ extension BaseCloudKitTests {
           [
             [0]: """
             CREATE TRIGGER "after_delete_on_sqlitedata_icloud_metadata"
-            AFTER UPDATE OF "isDeleted" ON "sqlitedata_icloud_metadata"
-            FOR EACH ROW WHEN ((NOT ("old"."isDeleted") AND "new"."isDeleted") AND NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges())) BEGIN
+            AFTER UPDATE OF "_isDeleted" ON "sqlitedata_icloud_metadata"
+            FOR EACH ROW WHEN ((NOT ("old"."_isDeleted") AND "new"."_isDeleted") AND NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges())) BEGIN
               SELECT sqlitedata_icloud_didDelete("new"."recordName", coalesce("new"."lastKnownServerRecord", (
                 WITH "ancestorMetadatas" AS (
                   SELECT "sqlitedata_icloud_metadata"."recordName" AS "recordName", "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."lastKnownServerRecord" AS "lastKnownServerRecord"
@@ -60,7 +60,7 @@ extension BaseCloudKitTests {
             [2]: """
             CREATE TRIGGER "after_update_on_sqlitedata_icloud_metadata"
             AFTER UPDATE ON "sqlitedata_icloud_metadata"
-            FOR EACH ROW WHEN (("old"."isDeleted" = "new"."isDeleted") AND NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges())) BEGIN
+            FOR EACH ROW WHEN (("old"."_isDeleted" = "new"."_isDeleted") AND NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges())) BEGIN
               SELECT sqlitedata_icloud_didUpdate("new"."recordName", coalesce("new"."lastKnownServerRecord", (
                 WITH "ancestorMetadatas" AS (
                   SELECT "sqlitedata_icloud_metadata"."recordName" AS "recordName", "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."lastKnownServerRecord" AS "lastKnownServerRecord"
@@ -102,7 +102,7 @@ extension BaseCloudKitTests {
               FROM "rootShares"
               WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
-              SET "isDeleted" = 1
+              SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'childWithOnDeleteSetDefaults'));
             END
             """,
@@ -131,7 +131,7 @@ extension BaseCloudKitTests {
               FROM "rootShares"
               WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
-              SET "isDeleted" = 1
+              SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'childWithOnDeleteSetNulls'));
             END
             """,
@@ -160,7 +160,7 @@ extension BaseCloudKitTests {
               FROM "rootShares"
               WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
-              SET "isDeleted" = 1
+              SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelAs'));
             END
             """,
@@ -189,7 +189,7 @@ extension BaseCloudKitTests {
               FROM "rootShares"
               WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
-              SET "isDeleted" = 1
+              SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelBs'));
             END
             """,
@@ -218,7 +218,7 @@ extension BaseCloudKitTests {
               FROM "rootShares"
               WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
-              SET "isDeleted" = 1
+              SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelCs'));
             END
             """,
@@ -247,7 +247,7 @@ extension BaseCloudKitTests {
               FROM "rootShares"
               WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
-              SET "isDeleted" = 1
+              SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'parents'));
             END
             """,
@@ -276,7 +276,7 @@ extension BaseCloudKitTests {
               FROM "rootShares"
               WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
-              SET "isDeleted" = 1
+              SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminderTags'));
             END
             """,
@@ -305,7 +305,7 @@ extension BaseCloudKitTests {
               FROM "rootShares"
               WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
-              SET "isDeleted" = 1
+              SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersListAssets'));
             END
             """,
@@ -334,7 +334,7 @@ extension BaseCloudKitTests {
               FROM "rootShares"
               WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
-              SET "isDeleted" = 1
+              SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersListPrivates'));
             END
             """,
@@ -363,7 +363,7 @@ extension BaseCloudKitTests {
               FROM "rootShares"
               WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
-              SET "isDeleted" = 1
+              SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersLists'));
             END
             """,
@@ -392,7 +392,7 @@ extension BaseCloudKitTests {
               FROM "rootShares"
               WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
-              SET "isDeleted" = 1
+              SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminders'));
             END
             """,
@@ -421,7 +421,7 @@ extension BaseCloudKitTests {
               FROM "rootShares"
               WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
-              SET "isDeleted" = 1
+              SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."title") AND ("sqlitedata_icloud_metadata"."recordType" = 'tags'));
             END
             """,

--- a/Tests/SharingGRDBTests/CloudKitTests/TriggerTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/TriggerTests.swift
@@ -19,13 +19,13 @@ extension BaseCloudKitTests {
           [
             [0]: """
             CREATE TRIGGER "after_delete_on_sqlitedata_icloud_metadata"
-            AFTER DELETE ON "sqlitedata_icloud_metadata"
-            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
-              SELECT sqlitedata_icloud_didDelete("old"."recordName", coalesce("old"."lastKnownServerRecord", (
+            AFTER UPDATE OF "isDeleted" ON "sqlitedata_icloud_metadata"
+            FOR EACH ROW WHEN (NOT ("old"."isDeleted") AND "new"."isDeleted") BEGIN
+              SELECT sqlitedata_icloud_didDelete("new"."recordName", coalesce("new"."lastKnownServerRecord", (
                 WITH "ancestorMetadatas" AS (
                   SELECT "sqlitedata_icloud_metadata"."recordName" AS "recordName", "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."lastKnownServerRecord" AS "lastKnownServerRecord"
                   FROM "sqlitedata_icloud_metadata"
-                  WHERE ("sqlitedata_icloud_metadata"."recordName" = "old"."recordName")
+                  WHERE ("sqlitedata_icloud_metadata"."recordName" = "new"."recordName")
                     UNION ALL
                   SELECT "sqlitedata_icloud_metadata"."recordName" AS "recordName", "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."lastKnownServerRecord" AS "lastKnownServerRecord"
                   FROM "sqlitedata_icloud_metadata"
@@ -34,7 +34,7 @@ extension BaseCloudKitTests {
                 SELECT "ancestorMetadatas"."lastKnownServerRecord"
                 FROM "ancestorMetadatas"
                 WHERE ("ancestorMetadatas"."parentRecordName" IS NULL)
-              )));
+              )), "new"."share");
             END
             """,
             [1]: """
@@ -54,7 +54,7 @@ extension BaseCloudKitTests {
                 SELECT "ancestorMetadatas"."lastKnownServerRecord"
                 FROM "ancestorMetadatas"
                 WHERE ("ancestorMetadatas"."parentRecordName" IS NULL)
-              )));
+              )), "new"."share");
             END
             """,
             [2]: """
@@ -74,106 +74,214 @@ extension BaseCloudKitTests {
                 SELECT "ancestorMetadatas"."lastKnownServerRecord"
                 FROM "ancestorMetadatas"
                 WHERE ("ancestorMetadatas"."parentRecordName" IS NULL)
-              )));
+              )), "new"."share");
             END
             """,
             [3]: """
-            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_childWithOnDeleteSetDefaults"
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_childWithOnDeleteSetDefaults_from_sync_engine"
             AFTER DELETE ON "childWithOnDeleteSetDefaults"
-            FOR EACH ROW BEGIN
+            FOR EACH ROW WHEN sqlitedata_icloud_syncEngineIsSynchronizingChanges() BEGIN
               DELETE FROM "sqlitedata_icloud_metadata"
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'childWithOnDeleteSetDefaults'));
             END
             """,
             [4]: """
-            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_childWithOnDeleteSetNulls"
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_childWithOnDeleteSetDefaults_from_user"
+            AFTER DELETE ON "childWithOnDeleteSetDefaults"
+            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'childWithOnDeleteSetDefaults'));
+            END
+            """,
+            [5]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_childWithOnDeleteSetNulls_from_sync_engine"
             AFTER DELETE ON "childWithOnDeleteSetNulls"
-            FOR EACH ROW BEGIN
+            FOR EACH ROW WHEN sqlitedata_icloud_syncEngineIsSynchronizingChanges() BEGIN
               DELETE FROM "sqlitedata_icloud_metadata"
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'childWithOnDeleteSetNulls'));
             END
             """,
-            [5]: """
-            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_modelAs"
+            [6]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_childWithOnDeleteSetNulls_from_user"
+            AFTER DELETE ON "childWithOnDeleteSetNulls"
+            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'childWithOnDeleteSetNulls'));
+            END
+            """,
+            [7]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_modelAs_from_sync_engine"
             AFTER DELETE ON "modelAs"
-            FOR EACH ROW BEGIN
+            FOR EACH ROW WHEN sqlitedata_icloud_syncEngineIsSynchronizingChanges() BEGIN
               DELETE FROM "sqlitedata_icloud_metadata"
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelAs'));
             END
             """,
-            [6]: """
-            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_modelBs"
+            [8]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_modelAs_from_user"
+            AFTER DELETE ON "modelAs"
+            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelAs'));
+            END
+            """,
+            [9]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_modelBs_from_sync_engine"
             AFTER DELETE ON "modelBs"
-            FOR EACH ROW BEGIN
+            FOR EACH ROW WHEN sqlitedata_icloud_syncEngineIsSynchronizingChanges() BEGIN
               DELETE FROM "sqlitedata_icloud_metadata"
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelBs'));
             END
             """,
-            [7]: """
-            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_modelCs"
+            [10]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_modelBs_from_user"
+            AFTER DELETE ON "modelBs"
+            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelBs'));
+            END
+            """,
+            [11]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_modelCs_from_sync_engine"
             AFTER DELETE ON "modelCs"
-            FOR EACH ROW BEGIN
+            FOR EACH ROW WHEN sqlitedata_icloud_syncEngineIsSynchronizingChanges() BEGIN
               DELETE FROM "sqlitedata_icloud_metadata"
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelCs'));
             END
             """,
-            [8]: """
-            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_parents"
+            [12]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_modelCs_from_user"
+            AFTER DELETE ON "modelCs"
+            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelCs'));
+            END
+            """,
+            [13]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_parents_from_sync_engine"
             AFTER DELETE ON "parents"
-            FOR EACH ROW BEGIN
+            FOR EACH ROW WHEN sqlitedata_icloud_syncEngineIsSynchronizingChanges() BEGIN
               DELETE FROM "sqlitedata_icloud_metadata"
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'parents'));
             END
             """,
-            [9]: """
-            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_reminderTags"
+            [14]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_parents_from_user"
+            AFTER DELETE ON "parents"
+            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'parents'));
+            END
+            """,
+            [15]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_reminderTags_from_sync_engine"
             AFTER DELETE ON "reminderTags"
-            FOR EACH ROW BEGIN
+            FOR EACH ROW WHEN sqlitedata_icloud_syncEngineIsSynchronizingChanges() BEGIN
               DELETE FROM "sqlitedata_icloud_metadata"
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminderTags'));
             END
             """,
-            [10]: """
-            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_reminders"
-            AFTER DELETE ON "reminders"
-            FOR EACH ROW BEGIN
-              DELETE FROM "sqlitedata_icloud_metadata"
-              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminders'));
+            [16]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_reminderTags_from_user"
+            AFTER DELETE ON "reminderTags"
+            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminderTags'));
             END
             """,
-            [11]: """
-            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_remindersListAssets"
+            [17]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_remindersListAssets_from_sync_engine"
             AFTER DELETE ON "remindersListAssets"
-            FOR EACH ROW BEGIN
+            FOR EACH ROW WHEN sqlitedata_icloud_syncEngineIsSynchronizingChanges() BEGIN
               DELETE FROM "sqlitedata_icloud_metadata"
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersListAssets'));
             END
             """,
-            [12]: """
-            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_remindersListPrivates"
+            [18]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_remindersListAssets_from_user"
+            AFTER DELETE ON "remindersListAssets"
+            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersListAssets'));
+            END
+            """,
+            [19]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_remindersListPrivates_from_sync_engine"
             AFTER DELETE ON "remindersListPrivates"
-            FOR EACH ROW BEGIN
+            FOR EACH ROW WHEN sqlitedata_icloud_syncEngineIsSynchronizingChanges() BEGIN
               DELETE FROM "sqlitedata_icloud_metadata"
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersListPrivates'));
             END
             """,
-            [13]: """
-            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_remindersLists"
+            [20]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_remindersListPrivates_from_user"
+            AFTER DELETE ON "remindersListPrivates"
+            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersListPrivates'));
+            END
+            """,
+            [21]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_remindersLists_from_sync_engine"
             AFTER DELETE ON "remindersLists"
-            FOR EACH ROW BEGIN
+            FOR EACH ROW WHEN sqlitedata_icloud_syncEngineIsSynchronizingChanges() BEGIN
               DELETE FROM "sqlitedata_icloud_metadata"
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersLists'));
             END
             """,
-            [14]: """
-            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_tags"
+            [22]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_remindersLists_from_user"
+            AFTER DELETE ON "remindersLists"
+            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersLists'));
+            END
+            """,
+            [23]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_reminders_from_sync_engine"
+            AFTER DELETE ON "reminders"
+            FOR EACH ROW WHEN sqlitedata_icloud_syncEngineIsSynchronizingChanges() BEGIN
+              DELETE FROM "sqlitedata_icloud_metadata"
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminders'));
+            END
+            """,
+            [24]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_reminders_from_user"
+            AFTER DELETE ON "reminders"
+            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminders'));
+            END
+            """,
+            [25]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_tags_from_sync_engine"
             AFTER DELETE ON "tags"
-            FOR EACH ROW BEGIN
+            FOR EACH ROW WHEN sqlitedata_icloud_syncEngineIsSynchronizingChanges() BEGIN
               DELETE FROM "sqlitedata_icloud_metadata"
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."title") AND ("sqlitedata_icloud_metadata"."recordType" = 'tags'));
             END
             """,
-            [15]: """
+            [26]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_delete_on_tags_from_user"
+            AFTER DELETE ON "tags"
+            FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."title") AND ("sqlitedata_icloud_metadata"."recordType" = 'tags'));
+            END
+            """,
+            [27]: """
             CREATE TRIGGER "sqlitedata_icloud_after_insert_on_childWithOnDeleteSetDefaults"
             AFTER INSERT ON "childWithOnDeleteSetDefaults"
             FOR EACH ROW BEGIN
@@ -184,7 +292,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [16]: """
+            [28]: """
             CREATE TRIGGER "sqlitedata_icloud_after_insert_on_childWithOnDeleteSetNulls"
             AFTER INSERT ON "childWithOnDeleteSetNulls"
             FOR EACH ROW BEGIN
@@ -195,7 +303,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [17]: """
+            [29]: """
             CREATE TRIGGER "sqlitedata_icloud_after_insert_on_modelAs"
             AFTER INSERT ON "modelAs"
             FOR EACH ROW BEGIN
@@ -206,7 +314,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [18]: """
+            [30]: """
             CREATE TRIGGER "sqlitedata_icloud_after_insert_on_modelBs"
             AFTER INSERT ON "modelBs"
             FOR EACH ROW BEGIN
@@ -217,7 +325,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [19]: """
+            [31]: """
             CREATE TRIGGER "sqlitedata_icloud_after_insert_on_modelCs"
             AFTER INSERT ON "modelCs"
             FOR EACH ROW BEGIN
@@ -228,7 +336,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [20]: """
+            [32]: """
             CREATE TRIGGER "sqlitedata_icloud_after_insert_on_parents"
             AFTER INSERT ON "parents"
             FOR EACH ROW BEGIN
@@ -239,7 +347,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [21]: """
+            [33]: """
             CREATE TRIGGER "sqlitedata_icloud_after_insert_on_reminderTags"
             AFTER INSERT ON "reminderTags"
             FOR EACH ROW BEGIN
@@ -250,7 +358,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [22]: """
+            [34]: """
             CREATE TRIGGER "sqlitedata_icloud_after_insert_on_reminders"
             AFTER INSERT ON "reminders"
             FOR EACH ROW BEGIN
@@ -261,7 +369,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [23]: """
+            [35]: """
             CREATE TRIGGER "sqlitedata_icloud_after_insert_on_remindersListAssets"
             AFTER INSERT ON "remindersListAssets"
             FOR EACH ROW BEGIN
@@ -272,7 +380,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [24]: """
+            [36]: """
             CREATE TRIGGER "sqlitedata_icloud_after_insert_on_remindersListPrivates"
             AFTER INSERT ON "remindersListPrivates"
             FOR EACH ROW BEGIN
@@ -283,7 +391,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [25]: """
+            [37]: """
             CREATE TRIGGER "sqlitedata_icloud_after_insert_on_remindersLists"
             AFTER INSERT ON "remindersLists"
             FOR EACH ROW BEGIN
@@ -294,7 +402,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [26]: """
+            [38]: """
             CREATE TRIGGER "sqlitedata_icloud_after_insert_on_tags"
             AFTER INSERT ON "tags"
             FOR EACH ROW BEGIN
@@ -305,7 +413,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [27]: """
+            [39]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_childWithOnDeleteSetDefaults"
             AFTER UPDATE ON "childWithOnDeleteSetDefaults"
             FOR EACH ROW BEGIN
@@ -316,7 +424,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [28]: """
+            [40]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_childWithOnDeleteSetNulls"
             AFTER UPDATE ON "childWithOnDeleteSetNulls"
             FOR EACH ROW BEGIN
@@ -327,7 +435,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [29]: """
+            [41]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_modelAs"
             AFTER UPDATE ON "modelAs"
             FOR EACH ROW BEGIN
@@ -338,7 +446,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [30]: """
+            [42]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_modelBs"
             AFTER UPDATE ON "modelBs"
             FOR EACH ROW BEGIN
@@ -349,7 +457,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [31]: """
+            [43]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_modelCs"
             AFTER UPDATE ON "modelCs"
             FOR EACH ROW BEGIN
@@ -360,7 +468,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [32]: """
+            [44]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_parents"
             AFTER UPDATE ON "parents"
             FOR EACH ROW BEGIN
@@ -371,7 +479,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [33]: """
+            [45]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_reminderTags"
             AFTER UPDATE ON "reminderTags"
             FOR EACH ROW BEGIN
@@ -382,7 +490,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [34]: """
+            [46]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_reminders"
             AFTER UPDATE ON "reminders"
             FOR EACH ROW BEGIN
@@ -393,7 +501,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [35]: """
+            [47]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_remindersListAssets"
             AFTER UPDATE ON "remindersListAssets"
             FOR EACH ROW BEGIN
@@ -404,7 +512,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [36]: """
+            [48]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_remindersListPrivates"
             AFTER UPDATE ON "remindersListPrivates"
             FOR EACH ROW BEGIN
@@ -415,7 +523,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [37]: """
+            [49]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_remindersLists"
             AFTER UPDATE ON "remindersLists"
             FOR EACH ROW BEGIN
@@ -426,7 +534,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [38]: """
+            [50]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_tags"
             AFTER UPDATE ON "tags"
             FOR EACH ROW BEGIN

--- a/Tests/SharingGRDBTests/CloudKitTests/TriggerTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/TriggerTests.swift
@@ -89,6 +89,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_delete_on_childWithOnDeleteSetDefaults_from_user"
             AFTER DELETE ON "childWithOnDeleteSetDefaults"
             FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "old"."parentID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'parents'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'childWithOnDeleteSetDefaults'));
@@ -106,6 +118,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_delete_on_childWithOnDeleteSetNulls_from_user"
             AFTER DELETE ON "childWithOnDeleteSetNulls"
             FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "old"."parentID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'parents'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'childWithOnDeleteSetNulls'));
@@ -123,6 +147,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_delete_on_modelAs_from_user"
             AFTER DELETE ON "modelAs"
             FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelAs'));
@@ -140,6 +176,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_delete_on_modelBs_from_user"
             AFTER DELETE ON "modelBs"
             FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "old"."modelAID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'modelAs'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelBs'));
@@ -157,6 +205,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_delete_on_modelCs_from_user"
             AFTER DELETE ON "modelCs"
             FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "old"."modelBID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'modelBs'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelCs'));
@@ -174,6 +234,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_delete_on_parents_from_user"
             AFTER DELETE ON "parents"
             FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'parents'));
@@ -191,6 +263,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_delete_on_reminderTags_from_user"
             AFTER DELETE ON "reminderTags"
             FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminderTags'));
@@ -208,6 +292,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_delete_on_remindersListAssets_from_user"
             AFTER DELETE ON "remindersListAssets"
             FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "old"."remindersListID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'remindersLists'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersListAssets'));
@@ -225,6 +321,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_delete_on_remindersListPrivates_from_user"
             AFTER DELETE ON "remindersListPrivates"
             FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "old"."remindersListID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'remindersLists'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersListPrivates'));
@@ -242,6 +350,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_delete_on_remindersLists_from_user"
             AFTER DELETE ON "remindersLists"
             FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersLists'));
@@ -259,6 +379,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_delete_on_reminders_from_user"
             AFTER DELETE ON "reminders"
             FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "old"."remindersListID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'remindersLists'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminders'));
@@ -276,6 +408,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_delete_on_tags_from_user"
             AFTER DELETE ON "tags"
             FOR EACH ROW WHEN NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."title") AND ("sqlitedata_icloud_metadata"."recordType" = 'tags'));
@@ -561,6 +705,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_childWithOnDeleteSetDefaults"
             AFTER UPDATE ON "childWithOnDeleteSetDefaults"
             FOR EACH ROW BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."parentID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'parents'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'childWithOnDeleteSetDefaults', "new"."parentID", 'parents'
@@ -572,6 +728,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_childWithOnDeleteSetNulls"
             AFTER UPDATE ON "childWithOnDeleteSetNulls"
             FOR EACH ROW BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."parentID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'parents'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'childWithOnDeleteSetNulls', "new"."parentID", 'parents'
@@ -583,6 +751,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_modelAs"
             AFTER UPDATE ON "modelAs"
             FOR EACH ROW BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'modelAs', NULL, NULL
@@ -594,6 +774,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_modelBs"
             AFTER UPDATE ON "modelBs"
             FOR EACH ROW BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."modelAID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'modelAs'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'modelBs', "new"."modelAID", 'modelAs'
@@ -605,6 +797,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_modelCs"
             AFTER UPDATE ON "modelCs"
             FOR EACH ROW BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."modelBID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'modelBs'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'modelCs', "new"."modelBID", 'modelBs'
@@ -616,6 +820,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_parents"
             AFTER UPDATE ON "parents"
             FOR EACH ROW BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'parents', NULL, NULL
@@ -627,6 +843,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_reminderTags"
             AFTER UPDATE ON "reminderTags"
             FOR EACH ROW BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'reminderTags', NULL, NULL
@@ -638,6 +866,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_reminders"
             AFTER UPDATE ON "reminders"
             FOR EACH ROW BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."remindersListID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'remindersLists'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'reminders', "new"."remindersListID", 'remindersLists'
@@ -649,6 +889,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_remindersListAssets"
             AFTER UPDATE ON "remindersListAssets"
             FOR EACH ROW BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."remindersListID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'remindersLists'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'remindersListAssets', "new"."remindersListID", 'remindersLists'
@@ -660,6 +912,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_remindersListPrivates"
             AFTER UPDATE ON "remindersListPrivates"
             FOR EACH ROW BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."remindersListID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'remindersLists'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'remindersListPrivates', "new"."remindersListID", 'remindersLists'
@@ -671,6 +935,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_remindersLists"
             AFTER UPDATE ON "remindersLists"
             FOR EACH ROW BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'remindersLists', NULL, NULL
@@ -682,6 +958,18 @@ extension BaseCloudKitTests {
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_tags"
             AFTER UPDATE ON "tags"
             FOR EACH ROW BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."title", 'tags', NULL, NULL

--- a/Tests/SharingGRDBTests/Internal/BaseCloudKitTests.swift
+++ b/Tests/SharingGRDBTests/Internal/BaseCloudKitTests.swift
@@ -25,8 +25,6 @@ class BaseCloudKitTests: @unchecked Sendable {
     _syncEngine as! SyncEngine
   }
 
-  typealias SendablePrimaryKeyedTable<T> = PrimaryKeyedTable<T> & Sendable
-
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   init(
     accountStatus: CKAccountStatus = _AccountStatusScope.accountStatus,


### PR DESCRIPTION
This PR adds a bunch of improvements to edge cases of sharing:

* When a user deletes a shared record, we now also delete the associated `CKShare`.
  * _However_, when the _sharee_ is the one deleting the shared record, we must _only_ delete the `CKShare` and not delete any of the actual records from CloudKit. Doing so causes an error in CloudKit because you have relinquished access to the record and so you are not allowed to delete it or its children records.
* When one creates/writes/deletes a record that is in a shared context (whether it be the root record or an associated record) we reference the share's permissions (if it exists) to see if you are allowed to make edits. If you are not allowed to make edits the database request will fail with a specific error that you can catch if needed.

Things left to do:

* If we ever get a permission error in `sentRecordZoneChanges` we need to either delete the local record or revert it to what is stored on CloudKit. Will do in a followup PR.
* We need to write some tests, but that requires a bit of infrastructure work to wiggle ourselves into the `CKShare` APIs. Will do in a followup PR.