### PR TITLE
More sharing tests and improvements

### DIFF
--- a/Sources/SharingGRDBCore/CloudKit/Triggers.swift
+++ b/Sources/SharingGRDBCore/CloudKit/Triggers.swift
@@ -238,7 +238,8 @@
           )
         }
         .where {
-          $0.parentRecordName.is(nil)
+          !SyncEngine.isSynchronizingChanges()
+            && $0.parentRecordName.is(nil)
             && !SQLQueryExpression(
               "\(raw: String.sqliteDataCloudKitSchemaName)_hasPermission(\($0.share))"
             )

--- a/Tests/SharingGRDBTests/CloudKitTests/AccountLifecycleTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/AccountLifecycleTests.swift
@@ -59,7 +59,7 @@ extension BaseCloudKitTests {
 
       try await syncEngine.processPendingDatabaseChanges(scope: .private)
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(

--- a/Tests/SharingGRDBTests/CloudKitTests/AssetsTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/AssetsTests.swift
@@ -26,7 +26,7 @@ extension BaseCloudKitTests {
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -82,7 +82,7 @@ extension BaseCloudKitTests {
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(

--- a/Tests/SharingGRDBTests/CloudKitTests/CloudKitTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/CloudKitTests.swift
@@ -460,7 +460,7 @@ extension BaseCloudKitTests {
         }
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -506,7 +506,7 @@ extension BaseCloudKitTests {
         }
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -587,7 +587,7 @@ extension BaseCloudKitTests {
           .execute(db)
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -622,7 +622,7 @@ extension BaseCloudKitTests {
         }
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -653,7 +653,7 @@ extension BaseCloudKitTests {
           .execute(db)
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -677,7 +677,7 @@ extension BaseCloudKitTests {
         }
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -728,7 +728,7 @@ extension BaseCloudKitTests {
         }
       )
       #expect(metadata.userModificationDate == serverModificationDate)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -773,7 +773,7 @@ extension BaseCloudKitTests {
       let record = try syncEngine.private.database.record(for: RemindersList.recordID(for: 1))
       try await syncEngine.modifyRecords(scope: .private, saving: [record]).notify()
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -806,7 +806,7 @@ extension BaseCloudKitTests {
         }
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -856,7 +856,7 @@ extension BaseCloudKitTests {
         }
       )
       #expect(metadata.userModificationDate == userModificationDate)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -889,7 +889,7 @@ extension BaseCloudKitTests {
         }
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -926,7 +926,7 @@ extension BaseCloudKitTests {
           .fetchOne(db)
       }
       #expect(metadata == nil)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -976,7 +976,7 @@ extension BaseCloudKitTests {
         }
 
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-        assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+        assertInlineSnapshot(of: container, as: .customDump) {
           """
           MockCloudContainer(
             privateCloudDatabase: MockCloudDatabase(

--- a/Tests/SharingGRDBTests/CloudKitTests/FetchRecordZoneChangesTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/FetchRecordZoneChangesTests.swift
@@ -211,7 +211,7 @@ extension BaseCloudKitTests {
 
       try await syncEngine.modifyRecords(scope: .private, saving: [remindersListRecord]).notify()
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -254,7 +254,7 @@ extension BaseCloudKitTests {
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
       }
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -310,7 +310,7 @@ extension BaseCloudKitTests {
       )
       try await syncEngine.modifyRecords(scope: .private, saving: [reminderRecord]).notify()
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -375,7 +375,7 @@ extension BaseCloudKitTests {
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
       }
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(

--- a/Tests/SharingGRDBTests/CloudKitTests/FetchedDatabaseChangesTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/FetchedDatabaseChangesTests.swift
@@ -74,7 +74,7 @@ extension BaseCloudKitTests {
         try #expect(UnsyncedModel.count().fetchOne(db) == 2)
       }
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(

--- a/Tests/SharingGRDBTests/CloudKitTests/ForeignKeyConstraintTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/ForeignKeyConstraintTests.swift
@@ -35,7 +35,7 @@ extension BaseCloudKitTests {
       )
       try await syncEngine.modifyRecords(scope: .private, saving: [reminderRecord]).notify()
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -107,7 +107,7 @@ extension BaseCloudKitTests {
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
       }
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -184,7 +184,7 @@ extension BaseCloudKitTests {
         )
       }
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -246,7 +246,7 @@ extension BaseCloudKitTests {
       )
       .notify()
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -316,7 +316,7 @@ extension BaseCloudKitTests {
       _ = try { try syncEngine.modifyRecords(scope: .private, saving: [remindersListRecord]) }()
       try await syncEngine.modifyRecords(scope: .private, saving: [reminderRecord]).notify()
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -397,7 +397,7 @@ extension BaseCloudKitTests {
         try await relaunchedSyncEngine.processPendingRecordZoneChanges(scope: .private)
       }
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -474,7 +474,7 @@ extension BaseCloudKitTests {
         saving: [reminderRecord, personalListRecord]
       ).notify()
       
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -526,7 +526,7 @@ extension BaseCloudKitTests {
       
       await modifications.notify()
       
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -779,7 +779,7 @@ extension BaseCloudKitTests {
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(

--- a/Tests/SharingGRDBTests/CloudKitTests/MergeConflictTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/MergeConflictTests.swift
@@ -18,7 +18,7 @@ extension BaseCloudKitTests {
         }
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -76,7 +76,7 @@ extension BaseCloudKitTests {
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -121,7 +121,7 @@ extension BaseCloudKitTests {
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
       await modificationCallback.notify()
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -172,7 +172,7 @@ extension BaseCloudKitTests {
         }
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -230,7 +230,7 @@ extension BaseCloudKitTests {
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -275,7 +275,7 @@ extension BaseCloudKitTests {
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
       await modificationCallback.notify()
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -344,7 +344,7 @@ extension BaseCloudKitTests {
       await modificationCallback.notify()
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -420,7 +420,7 @@ extension BaseCloudKitTests {
         )
       }
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -489,7 +489,7 @@ extension BaseCloudKitTests {
       await modificationCallback.notify()
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -559,7 +559,7 @@ extension BaseCloudKitTests {
       await modificationCallback.notify()
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -636,7 +636,7 @@ extension BaseCloudKitTests {
       await modificationsFinished.notify()
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(

--- a/Tests/SharingGRDBTests/CloudKitTests/MetadataTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/MetadataTests.swift
@@ -21,7 +21,7 @@ extension BaseCloudKitTests {
       }
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -91,7 +91,7 @@ extension BaseCloudKitTests {
       }
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -145,7 +145,7 @@ extension BaseCloudKitTests {
       }
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(

--- a/Tests/SharingGRDBTests/CloudKitTests/MockCloudDatabaseTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/MockCloudDatabaseTests.swift
@@ -56,7 +56,7 @@ extension BaseCloudKitTests {
       )
       #expect(saveRecordResults.allSatisfy({ (try? $1.get()) != nil }))
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -102,7 +102,7 @@ extension BaseCloudKitTests {
 
       try await syncEngine.modifyRecords(scope: .private, saving: [child]).notify()
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -134,7 +134,7 @@ extension BaseCloudKitTests {
       }
       #expect(error == CKError(.zoneNotFound))
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -162,7 +162,7 @@ extension BaseCloudKitTests {
       )
       #expect(deleteResults.allSatisfy({ (try? $1.get()) != nil }))
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -187,7 +187,7 @@ extension BaseCloudKitTests {
       )
       #expect(deleteResults.allSatisfy({ (try? $1.get()) != nil }))
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -218,7 +218,7 @@ extension BaseCloudKitTests {
       }
       #expect(error == CKError(.zoneNotFound))
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -249,7 +249,7 @@ extension BaseCloudKitTests {
       }
       #expect(error == CKError(.referenceViolation))
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(

--- a/Tests/SharingGRDBTests/CloudKitTests/NewTableSyncTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/NewTableSyncTests.swift
@@ -25,7 +25,7 @@ extension BaseCloudKitTests {
     @Test
     func initialSync() async throws {
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(

--- a/Tests/SharingGRDBTests/CloudKitTests/NextRecordZoneChangeBatchTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/NextRecordZoneChangeBatchTests.swift
@@ -15,7 +15,7 @@ extension BaseCloudKitTests {
       )
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -44,7 +44,7 @@ extension BaseCloudKitTests {
       }
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -73,7 +73,7 @@ extension BaseCloudKitTests {
       }
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -97,7 +97,7 @@ extension BaseCloudKitTests {
       }
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -132,7 +132,7 @@ extension BaseCloudKitTests {
       }
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -176,7 +176,7 @@ extension BaseCloudKitTests {
       }
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(

--- a/Tests/SharingGRDBTests/CloudKitTests/ReferenceViolationTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/ReferenceViolationTests.swift
@@ -41,7 +41,7 @@ extension BaseCloudKitTests {
       await modifications.notify()
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -115,7 +115,7 @@ extension BaseCloudKitTests {
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
       await modifications.notify()
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -199,7 +199,7 @@ extension BaseCloudKitTests {
       await modifications.notify()
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
           """
           MockCloudContainer(
             privateCloudDatabase: MockCloudDatabase(
@@ -277,7 +277,7 @@ extension BaseCloudKitTests {
         await modifications.notify()
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-        assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+        assertInlineSnapshot(of: container, as: .customDump) {
           """
           MockCloudContainer(
             privateCloudDatabase: MockCloudDatabase(
@@ -357,7 +357,7 @@ extension BaseCloudKitTests {
         await modifications.notify()
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-        assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+        assertInlineSnapshot(of: container, as: .customDump) {
           """
           MockCloudContainer(
             privateCloudDatabase: MockCloudDatabase(

--- a/Tests/SharingGRDBTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/SharingTests.swift
@@ -27,7 +27,7 @@ extension BaseCloudKitTests {
       }
       assertInlineSnapshot(of: error?.localizedDescription, as: .customDump) {
         """
-        "The record could not be shared."
+        "An error occured when editing sharing."
         """
       }
       assertInlineSnapshot(of: error, as: .customDump) {
@@ -66,7 +66,7 @@ extension BaseCloudKitTests {
         as: .customDump
       ) {
         """
-        "The record could not be shared."
+        "An error occured when editing sharing."
         """
       }
       assertInlineSnapshot(of: error, as: .customDump) {
@@ -94,7 +94,7 @@ extension BaseCloudKitTests {
         as: .customDump
       ) {
         """
-        "The record could not be shared."
+        "An error occured when editing sharing."
         """
       }
       assertInlineSnapshot(of: error, as: .customDump) {
@@ -133,7 +133,7 @@ extension BaseCloudKitTests {
         as: .customDump
       ) {
         """
-        "The record could not be shared."
+        "An error occured when editing sharing."
         """
       }
       assertInlineSnapshot(of: error, as: .customDump) {
@@ -178,7 +178,7 @@ extension BaseCloudKitTests {
       }
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .shared)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -249,7 +249,7 @@ extension BaseCloudKitTests {
       try await syncEngine.modifyRecords(scope: .shared, saving: [newShare]).notify()
       try await syncEngine.modifyRecords(scope: .shared, saving: [newRemindersListRecord]).notify()
 
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -353,7 +353,7 @@ extension BaseCloudKitTests {
       }
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .shared)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -436,7 +436,7 @@ extension BaseCloudKitTests {
       }
 
       try await syncEngine.processPendingRecordZoneChanges(scope: .shared)
-      assertInlineSnapshot(of: syncEngine.container, as: .customDump) {
+      assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
@@ -509,6 +509,74 @@ extension BaseCloudKitTests {
         )
         """
       }
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func shareUnshareShareAgain() async throws {
+      let remindersList = RemindersList(id: 1, title: "Personal")
+      try await userDatabase.userWrite { db in
+        try db.seed {
+          remindersList
+        }
+      }
+      try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+      let _ = try await syncEngine.share(record: remindersList, configure: { _ in })
+
+      try await syncEngine.unshare(record: remindersList)
+
+      assertInlineSnapshot(of: container, as: .customDump) {
+        """
+        MockCloudContainer(
+          privateCloudDatabase: MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__))
+              )
+            ]
+          ),
+          sharedCloudDatabase: MockCloudDatabase(
+            databaseScope: .shared,
+            storage: []
+          )
+        )
+        """
+      }
+
+      let _ = try await syncEngine.share(record: remindersList, configure: { _ in })
+
+      assertInlineSnapshot(of: container, as: .customDump) {
+        """
+        MockCloudContainer(
+          privateCloudDatabase: MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(share-1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordType: "cloudkit.share",
+                parent: nil,
+                share: nil
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__))
+              )
+            ]
+          ),
+          sharedCloudDatabase: MockCloudDatabase(
+            databaseScope: .shared,
+            storage: []
+          )
+        )
+        """
+      }
+
     }
 
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
@@ -588,7 +656,6 @@ extension BaseCloudKitTests {
         """
       }
     }
-
 
     @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @Test func acceptShareCreateReminder() async throws {
@@ -679,6 +746,281 @@ extension BaseCloudKitTests {
           )
         )
         """
+      }
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func deleteRootSharedRecord_CurrentUserOwnsRecord() async throws {
+      let remindersList = RemindersList(id: 1, title: "Personal")
+      try await userDatabase.userWrite { db in
+        try db.seed {
+          remindersList
+        }
+      }
+      try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+      let _ = try await syncEngine.share(record: remindersList, configure: { _ in })
+
+      try await userDatabase.userWrite { db in
+        try RemindersList.find(1).delete().execute(db)
+      }
+      try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+      assertInlineSnapshot(of: container, as: .customDump) {
+        """
+        MockCloudContainer(
+          privateCloudDatabase: MockCloudDatabase(
+            databaseScope: .private,
+            storage: []
+          ),
+          sharedCloudDatabase: MockCloudDatabase(
+            databaseScope: .shared,
+            storage: []
+          )
+        )
+        """
+      }
+    }
+    
+    /// Deleting a root shared record that is not owned by current user should only delete
+    /// the share but not the actual records.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func deleteRootSharedRecord_CurrentUserNotOwner() async throws {
+      let externalZone = CKRecordZone(
+        zoneID: CKRecordZone.ID(
+          zoneName: "external.zone",
+          ownerName: "external.owner"
+        )
+      )
+      try await syncEngine.modifyRecordZones(scope: .shared, saving: [externalZone]).notify()
+
+      let remindersListRecord = CKRecord(
+        recordType: RemindersList.tableName,
+        recordID: RemindersList.recordID(for: 1, zoneID: externalZone.zoneID)
+      )
+      remindersListRecord.setValue(1, forKey: "id", at: now)
+      remindersListRecord.setValue("Personal", forKey: "title", at: now)
+      let share = CKShare(
+        rootRecord: remindersListRecord,
+        shareID: CKRecord.ID(
+          recordName: "share-\(remindersListRecord.recordID.recordName)",
+          zoneID: remindersListRecord.recordID.zoneID
+        )
+      )
+
+      try await syncEngine
+        .acceptShare(
+          metadata: ShareMetadata(
+            containerIdentifier: container.containerIdentifier!,
+            hierarchicalRootRecordID: remindersListRecord.recordID,
+            rootRecord: remindersListRecord,
+            share: share
+          )
+        )
+
+      try await userDatabase.userWrite { db in
+        try db.seed {
+          Reminder(id: 1, title: "Get milk", remindersListID: 1)
+        }
+      }
+
+      try await syncEngine.processPendingRecordZoneChanges(scope: .shared)
+
+      try await userDatabase.userWrite { db in
+        try RemindersList.find(1).delete().execute(db)
+      }
+
+      try await syncEngine.processPendingRecordZoneChanges(scope: .shared)
+
+      assertInlineSnapshot(of: container, as: .customDump) {
+        """
+        MockCloudContainer(
+          privateCloudDatabase: MockCloudDatabase(
+            databaseScope: .private,
+            storage: []
+          ),
+          sharedCloudDatabase: MockCloudDatabase(
+            databaseScope: .shared,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/external.zone/external.owner),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/external.zone/external.owner)),
+                share: nil,
+                id: 1,
+                isCompleted: 0,
+                remindersListID: 1,
+                title: "Get milk"
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/external.zone/external.owner),
+                recordType: "remindersLists",
+                parent: nil,
+                share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/external.zone/external.owner)),
+                id: 1,
+                title: "Personal"
+              )
+            ]
+          )
+        )
+        """
+      }
+    }
+
+    /// Inserting record into shared record when user does not have permission.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func insertRecordInReadOnlyRemindersList() async throws {
+      let externalZone = CKRecordZone(
+        zoneID: CKRecordZone.ID(
+          zoneName: "external.zone",
+          ownerName: "external.owner"
+        )
+      )
+      try await syncEngine.modifyRecordZones(scope: .shared, saving: [externalZone]).notify()
+
+      let remindersListRecord = CKRecord(
+        recordType: RemindersList.tableName,
+        recordID: RemindersList.recordID(for: 1, zoneID: externalZone.zoneID)
+      )
+      remindersListRecord.setValue(1, forKey: "id", at: now)
+      remindersListRecord.setValue("Personal", forKey: "title", at: now)
+      let share = CKShare(
+        rootRecord: remindersListRecord,
+        shareID: CKRecord.ID(
+          recordName: "share-\(remindersListRecord.recordID.recordName)",
+          zoneID: remindersListRecord.recordID.zoneID
+        )
+      )
+      share.publicPermission = .readOnly
+      share.currentUserParticipant?.permission = .readOnly
+
+      try await syncEngine
+        .acceptShare(
+          metadata: ShareMetadata(
+            containerIdentifier: container.containerIdentifier!,
+            hierarchicalRootRecordID: remindersListRecord.recordID,
+            rootRecord: remindersListRecord,
+            share: share
+          )
+        )
+
+      let error = await #expect(throws: DatabaseError.self) {
+        try await self.userDatabase.userWrite { db in
+          try db.seed {
+            Reminder(id: 1, title: "Get milk", remindersListID: 1)
+          }
+        }
+      }
+      #expect(error?.message == SyncEngine.writePermissionError)
+    }
+
+    /// Delete record in shared record when user does not have permission.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func deleteReminderInReadOnlyRemindersList() async throws {
+      let externalZone = CKRecordZone(
+        zoneID: CKRecordZone.ID(
+          zoneName: "external.zone",
+          ownerName: "external.owner"
+        )
+      )
+      try await syncEngine.modifyRecordZones(scope: .shared, saving: [externalZone]).notify()
+
+      let remindersListRecord = CKRecord(
+        recordType: RemindersList.tableName,
+        recordID: RemindersList.recordID(for: 1, zoneID: externalZone.zoneID)
+      )
+      remindersListRecord.setValue(1, forKey: "id", at: now)
+      remindersListRecord.setValue("Personal", forKey: "title", at: now)
+      let share = CKShare(
+        rootRecord: remindersListRecord,
+        shareID: CKRecord.ID(
+          recordName: "share-\(remindersListRecord.recordID.recordName)",
+          zoneID: remindersListRecord.recordID.zoneID
+        )
+      )
+      share.publicPermission = .readOnly
+      share.currentUserParticipant?.permission = .readOnly
+
+      try await syncEngine
+        .acceptShare(
+          metadata: ShareMetadata(
+            containerIdentifier: container.containerIdentifier!,
+            hierarchicalRootRecordID: remindersListRecord.recordID,
+            rootRecord: remindersListRecord,
+            share: share
+          )
+        )
+      let reminderRecord = CKRecord(
+        recordType: Reminder.tableName,
+        recordID: Reminder.recordID(for: 1, zoneID: externalZone.zoneID)
+      )
+      reminderRecord.setValue(1, forKey: "id", at: now)
+      reminderRecord.setValue("Get milk", forKey: "title", at: now)
+      reminderRecord.setValue(1, forKey: "remindersListID", at: now)
+      reminderRecord.parent = CKRecord.Reference(record: remindersListRecord, action: .none)
+      try await syncEngine.modifyRecords(scope: .shared, saving: [reminderRecord]).notify()
+
+      try await self.userDatabase.userWrite { db in
+        let error = #expect(throws: DatabaseError.self) {
+          try Reminder.find(1).delete().execute(db)
+        }
+        #expect(error?.message == SyncEngine.writePermissionError)
+        try #expect(Reminder.count().fetchOne(db) == 1)
+      }
+    }
+
+    /// Editing record in shared record when user does not have permission.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func editReminderInReadOnlyRemindersList() async throws {
+      let externalZone = CKRecordZone(
+        zoneID: CKRecordZone.ID(
+          zoneName: "external.zone",
+          ownerName: "external.owner"
+        )
+      )
+      try await syncEngine.modifyRecordZones(scope: .shared, saving: [externalZone]).notify()
+
+      let remindersListRecord = CKRecord(
+        recordType: RemindersList.tableName,
+        recordID: RemindersList.recordID(for: 1, zoneID: externalZone.zoneID)
+      )
+      remindersListRecord.setValue(1, forKey: "id", at: now)
+      remindersListRecord.setValue("Personal", forKey: "title", at: now)
+      let share = CKShare(
+        rootRecord: remindersListRecord,
+        shareID: CKRecord.ID(
+          recordName: "share-\(remindersListRecord.recordID.recordName)",
+          zoneID: remindersListRecord.recordID.zoneID
+        )
+      )
+      share.publicPermission = .readOnly
+      share.currentUserParticipant?.permission = .readOnly
+
+      try await syncEngine
+        .acceptShare(
+          metadata: ShareMetadata(
+            containerIdentifier: container.containerIdentifier!,
+            hierarchicalRootRecordID: remindersListRecord.recordID,
+            rootRecord: remindersListRecord,
+            share: share
+          )
+        )
+      let reminderRecord = CKRecord(
+        recordType: Reminder.tableName,
+        recordID: Reminder.recordID(for: 1, zoneID: externalZone.zoneID)
+      )
+      reminderRecord.setValue(1, forKey: "id", at: now)
+      reminderRecord.setValue("Get milk", forKey: "title", at: now)
+      reminderRecord.setValue(1, forKey: "remindersListID", at: now)
+      reminderRecord.parent = CKRecord.Reference(record: remindersListRecord, action: .none)
+      try await syncEngine.modifyRecords(scope: .shared, saving: [reminderRecord]).notify()
+
+      try await self.userDatabase.userWrite { db in
+        let error = #expect(throws: DatabaseError.self) {
+          try Reminder.find(1).delete().execute(db)
+        }
+        #expect(error?.message == SyncEngine.writePermissionError)
+        try #expect(Reminder.count().fetchOne(db) == 1)
       }
     }
   }

--- a/Tests/SharingGRDBTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/SharingTests.swift
@@ -1017,10 +1017,10 @@ extension BaseCloudKitTests {
 
       try await self.userDatabase.userWrite { db in
         let error = #expect(throws: DatabaseError.self) {
-          try Reminder.find(1).delete().execute(db)
+          try Reminder.update { $0.isCompleted = true }.execute(db)
         }
         #expect(error?.message == SyncEngine.writePermissionError)
-        try #expect(Reminder.count().fetchOne(db) == 1)
+        try #expect(Reminder.where(\.isCompleted).fetchCount(db) == 0)
       }
     }
   }

--- a/Tests/SharingGRDBTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/SharingTests.swift
@@ -766,6 +766,10 @@ extension BaseCloudKitTests {
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
+      try await userDatabase.userWrite { db in
+        #expect(try RemindersList.all.fetchCount(db) == 0)
+      }
+
       assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(

--- a/Tests/SharingGRDBTests/CloudKitTests/TriggerTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/TriggerTests.swift
@@ -100,7 +100,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'childWithOnDeleteSetDefaults'));
@@ -129,7 +129,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'childWithOnDeleteSetNulls'));
@@ -158,7 +158,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelAs'));
@@ -187,7 +187,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelBs'));
@@ -216,7 +216,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelCs'));
@@ -245,7 +245,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'parents'));
@@ -274,7 +274,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminderTags'));
@@ -303,7 +303,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersListAssets'));
@@ -332,7 +332,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersListPrivates'));
@@ -361,7 +361,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersLists'));
@@ -390,7 +390,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminders'));
@@ -419,7 +419,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               UPDATE "sqlitedata_icloud_metadata"
               SET "_isDeleted" = 1
               WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."title") AND ("sqlitedata_icloud_metadata"."recordType" = 'tags'));
@@ -440,7 +440,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'childWithOnDeleteSetDefaults', "new"."parentID", 'parents'
@@ -463,7 +463,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'childWithOnDeleteSetNulls', "new"."parentID", 'parents'
@@ -486,7 +486,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'modelAs', NULL, NULL
@@ -509,7 +509,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'modelBs', "new"."modelAID", 'modelAs'
@@ -532,7 +532,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'modelCs', "new"."modelBID", 'modelBs'
@@ -555,7 +555,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'parents', NULL, NULL
@@ -578,7 +578,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'reminderTags', NULL, NULL
@@ -601,7 +601,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'reminders', "new"."remindersListID", 'remindersLists'
@@ -624,7 +624,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'remindersListAssets', "new"."remindersListID", 'remindersLists'
@@ -647,7 +647,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'remindersListPrivates', "new"."remindersListID", 'remindersLists'
@@ -670,7 +670,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'remindersLists', NULL, NULL
@@ -693,7 +693,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."title", 'tags', NULL, NULL
@@ -716,7 +716,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'childWithOnDeleteSetDefaults', "new"."parentID", 'parents'
@@ -739,7 +739,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'childWithOnDeleteSetNulls', "new"."parentID", 'parents'
@@ -762,7 +762,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'modelAs', NULL, NULL
@@ -785,7 +785,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'modelBs', "new"."modelAID", 'modelAs'
@@ -808,7 +808,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'modelCs', "new"."modelBID", 'modelBs'
@@ -831,7 +831,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'parents', NULL, NULL
@@ -854,7 +854,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'reminderTags', NULL, NULL
@@ -877,7 +877,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'reminders', "new"."remindersListID", 'remindersLists'
@@ -900,7 +900,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'remindersListAssets', "new"."remindersListID", 'remindersLists'
@@ -923,7 +923,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'remindersListPrivates', "new"."remindersListID", 'remindersLists'
@@ -946,7 +946,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."id", 'remindersLists', NULL, NULL
@@ -969,7 +969,7 @@ extension BaseCloudKitTests {
               )
               SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
               FROM "rootShares"
-              WHERE (("rootShares"."parentRecordName" IS NULL) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
               INSERT INTO "sqlitedata_icloud_metadata"
               ("recordPrimaryKey", "recordType", "parentRecordPrimaryKey", "parentRecordType")
               SELECT "new"."title", 'tags', NULL, NULL

--- a/Tests/SharingGRDBTests/Internal/Schema.swift
+++ b/Tests/SharingGRDBTests/Internal/Schema.swift
@@ -75,9 +75,6 @@ func database(containerIdentifier: String) throws -> DatabasePool {
   var configuration = Configuration()
   configuration.prepareDatabase { db in
     try db.attachMetadatabase(containerIdentifier: containerIdentifier)
-    db.trace {
-      print($0.expandedDescription)
-    }
   }
   let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).sqlite")
   let database = try DatabasePool(path: url.path(), configuration: configuration)


### PR DESCRIPTION
With the improvements we made to the testability of sharing in #128 we can now write tests for behavior we added in #126. And it turns out we had a bug in that PR 😬. We are preventing changes being sync'd from CK to the user device when they have read only permissions. We need to bypass permission checks when rows are updated from the sync engine directly.