### PR TITLE
Update for swift-structured-queries boolean support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d87ac3bfcdef05674d1d54c62277ab77a7f1a74d2b106a3e0a8eb5567e2ff1ed",
+  "originHash" : "9a802312e08d4358c9db408c9aedbc8ab10742b58fd0d726bd35528aa89c08af",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -121,10 +121,10 @@
     {
       "identity" : "swift-structured-queries",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-structured-queries",
+      "location" : "https://github.com/coenttb/swift-structured-queries",
       "state" : {
-        "revision" : "b5b5a9ed9ff321f43a02f07394f2831eba5e11f2",
-        "version" : "0.13.0"
+        "branch" : "feature/native-boolean-support",
+        "revision" : "9d578b7271784eda2c799a02add5fc83eeca1848"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.5.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", from: "2.3.0"),
-    .package(url: "https://github.com/pointfreeco/swift-structured-queries", from: "0.13.0"),
+    .package(url: "https://github.com/coenttb/swift-structured-queries", branch: "feature/native-boolean-support"),
   ],
   targets: [
     .target(

--- a/Sources/StructuredQueriesGRDBCore/QueryCursor.swift
+++ b/Sources/StructuredQueriesGRDBCore/QueryCursor.swift
@@ -164,6 +164,8 @@ extension QueryBinding {
         return uuid.uuidString.lowercased().databaseValue
       case let .invalid(error):
         throw error
+      case let .bool(bool):
+          return bool.databaseValue
       }
     }
   }


### PR DESCRIPTION
## Summary

This PR updates SharingGRDB to support the new boolean type handling introduced in https://github.com/pointfreeco/swift-structured-queries/pull/141.

## Changes

- Updated `Package.swift` to point to the `feature/native-boolean-support` branch of swift-structured-queries
- Added handling for the new `.bool` case in `QueryCursor.swift`

## Context

As requested by @stephencelis in the swift-structured-queries PR, this demonstrates the changes needed in SharingGRDB to support proper boolean type handling for databases with native boolean types (like PostgreSQL) while maintaining backward compatibility with SQLite.

## Testing

All tests pass with these changes.