### PR TITLE
Add custom mirrors to property wrappers

### DIFF
--- a/Sources/SharingGRDBCore/Fetch.swift
+++ b/Sources/SharingGRDBCore/Fetch.swift
@@ -143,6 +143,12 @@ extension Fetch {
   }
 }
 
+extension Fetch: CustomReflectable {
+  public var customMirror: Mirror {
+    Mirror(reflecting: wrappedValue)
+  }
+}
+
 extension Fetch: Equatable where Value: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.sharedReader == rhs.sharedReader

--- a/Sources/SharingGRDBCore/FetchAll.swift
+++ b/Sources/SharingGRDBCore/FetchAll.swift
@@ -345,6 +345,12 @@ extension FetchAll {
   }
 }
 
+extension FetchAll: CustomReflectable {
+  public var customMirror: Mirror {
+    Mirror(reflecting: wrappedValue)
+  }
+}
+
 extension FetchAll: Equatable where Element: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.sharedReader == rhs.sharedReader

--- a/Sources/SharingGRDBCore/FetchOne.swift
+++ b/Sources/SharingGRDBCore/FetchOne.swift
@@ -814,6 +814,12 @@ extension FetchOne {
   }
 }
 
+extension FetchOne: CustomReflectable {
+  public var customMirror: Mirror {
+    Mirror(reflecting: wrappedValue)
+  }
+}
+
 extension FetchOne: Equatable where Value: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.sharedReader == rhs.sharedReader


### PR DESCRIPTION
This way the values are more transparent to Custom Dump.