### PR TITLE
Delete CK record when updating primary key.

### DIFF
--- a/Sources/SharingGRDBCore/Internal/UserDatabase.swift
+++ b/Sources/SharingGRDBCore/Internal/UserDatabase.swift
@@ -2,7 +2,7 @@ import Dependencies
 import GRDB
 
 package struct UserDatabase {
-  private let database: any DatabaseWriter
+  package let database: any DatabaseWriter
   package init(database: any DatabaseWriter) {
     self.database = database
   }

--- a/Tests/SharingGRDBTests/CloudKitTests/AccountLifecycleTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/AccountLifecycleTests.swift
@@ -67,9 +67,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 isCompleted: 0,
@@ -77,16 +77,16 @@ extension BaseCloudKitTests {
                 title: "Get milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersListPrivates/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersListPrivates/zone/__defaultOwner__),
                 recordType: "remindersListPrivates",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 position: 0,
                 remindersListID: 1
               ),
               [2]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,

--- a/Tests/SharingGRDBTests/CloudKitTests/AssetsTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/AssetsTests.swift
@@ -33,9 +33,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersListAssets/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersListAssets/zone/__defaultOwner__),
                 recordType: "remindersListAssets",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 remindersListID: 1,
@@ -45,7 +45,7 @@ extension BaseCloudKitTests {
                 )
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -89,9 +89,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersListAssets/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersListAssets/zone/__defaultOwner__),
                 recordType: "remindersListAssets",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 remindersListID: 1,
@@ -101,7 +101,7 @@ extension BaseCloudKitTests {
                 )
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,

--- a/Tests/SharingGRDBTests/CloudKitTests/CloudKitTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/CloudKitTests.swift
@@ -468,7 +468,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -515,7 +515,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -597,7 +597,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -632,7 +632,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -687,7 +687,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -738,7 +738,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -783,7 +783,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -816,7 +816,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -866,7 +866,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -899,7 +899,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -987,14 +987,14 @@ extension BaseCloudKitTests {
               databaseScope: .private,
               storage: [
                 [0]: CKRecord(
-                  recordID: CKRecord.ID(fun:tags/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(fun:tags/zone/__defaultOwner__),
                   recordType: "tags",
                   parent: nil,
                   share: nil,
                   title: "fun"
                 ),
                 [1]: CKRecord(
-                  recordID: CKRecord.ID(weekend:tags/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(weekend:tags/zone/__defaultOwner__),
                   recordType: "tags",
                   parent: nil,
                   share: nil,
@@ -1028,7 +1028,7 @@ extension BaseCloudKitTests {
           databaseScope: .private,
           storage: [
             [0]: CKRecord(
-              recordID: CKRecord.ID(1:modelAs/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+              recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),
               recordType: "modelAs",
               parent: nil,
               share: nil,
@@ -1057,7 +1057,7 @@ extension BaseCloudKitTests {
           databaseScope: .private,
           storage: [
             [0]: CKRecord(
-              recordID: CKRecord.ID(1:modelAs/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+              recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),
               recordType: "modelAs",
               parent: nil,
               share: nil,

--- a/Tests/SharingGRDBTests/CloudKitTests/FetchRecordZoneChangesTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/FetchRecordZoneChangesTests.swift
@@ -481,119 +481,14 @@ extension BaseCloudKitTests {
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
-      assertQuery(SyncMetadata.all, database: userDatabase.database) {
+      assertQuery(SyncMetadata.select(\.recordName), database: userDatabase.database) {
         """
-        ┌─────────────────────────────────────────────────────────────────────────────────────────┐
-        │ SyncMetadata(                                                                           │
-        │   recordPrimaryKey: "1",                                                                │
-        │   recordType: "remindersLists",                                                         │
-        │   recordName: "1:remindersLists",                                                       │
-        │   parentRecordPrimaryKey: nil,                                                          │
-        │   parentRecordType: nil,                                                                │
-        │   parentRecordName: nil,                                                                │
-        │   lastKnownServerRecord: CKRecord(                                                      │
-        │     recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),                      │
-        │     recordType: "remindersLists",                                                       │
-        │     parent: nil,                                                                        │
-        │     share: nil                                                                          │
-        │   ),                                                                                    │
-        │   _lastKnownServerRecordAllFields: CKRecord(                                            │
-        │     recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),                      │
-        │     recordType: "remindersLists",                                                       │
-        │     parent: nil,                                                                        │
-        │     share: nil,                                                                         │
-        │     id: 1,                                                                              │
-        │     title: "Personal"                                                                   │
-        │   ),                                                                                    │
-        │   share: nil,                                                                           │
-        │   _isDeleted: false,                                                                    │
-        │   isShared: false,                                                                      │
-        │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
-        │ )                                                                                       │
-        ├─────────────────────────────────────────────────────────────────────────────────────────┤
-        │ SyncMetadata(                                                                           │
-        │   recordPrimaryKey: "1",                                                                │
-        │   recordType: "reminders",                                                              │
-        │   recordName: "1:reminders",                                                            │
-        │   parentRecordPrimaryKey: "1",                                                          │
-        │   parentRecordType: "remindersLists",                                                   │
-        │   parentRecordName: "1:remindersLists",                                                 │
-        │   lastKnownServerRecord: CKRecord(                                                      │
-        │     recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),                           │
-        │     recordType: "reminders",                                                            │
-        │     parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)), │
-        │     share: nil                                                                          │
-        │   ),                                                                                    │
-        │   _lastKnownServerRecordAllFields: CKRecord(                                            │
-        │     recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),                           │
-        │     recordType: "reminders",                                                            │
-        │     parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)), │
-        │     share: nil,                                                                         │
-        │     id: 1,                                                                              │
-        │     isCompleted: 0,                                                                     │
-        │     remindersListID: 1,                                                                 │
-        │     title: "Get milk"                                                                   │
-        │   ),                                                                                    │
-        │   share: nil,                                                                           │
-        │   _isDeleted: false,                                                                    │
-        │   isShared: false,                                                                      │
-        │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
-        │ )                                                                                       │
-        ├─────────────────────────────────────────────────────────────────────────────────────────┤
-        │ SyncMetadata(                                                                           │
-        │   recordPrimaryKey: "1",                                                                │
-        │   recordType: "reminderTags",                                                           │
-        │   recordName: "1:reminderTags",                                                         │
-        │   parentRecordPrimaryKey: nil,                                                          │
-        │   parentRecordType: nil,                                                                │
-        │   parentRecordName: nil,                                                                │
-        │   lastKnownServerRecord: CKRecord(                                                      │
-        │     recordID: CKRecord.ID(1:reminderTags/zone/__defaultOwner__),                        │
-        │     recordType: "reminderTags",                                                         │
-        │     parent: nil,                                                                        │
-        │     share: nil                                                                          │
-        │   ),                                                                                    │
-        │   _lastKnownServerRecordAllFields: CKRecord(                                            │
-        │     recordID: CKRecord.ID(1:reminderTags/zone/__defaultOwner__),                        │
-        │     recordType: "reminderTags",                                                         │
-        │     parent: nil,                                                                        │
-        │     share: nil,                                                                         │
-        │     id: 1,                                                                              │
-        │     reminderID: 1,                                                                      │
-        │     tagID: "optional"                                                                   │
-        │   ),                                                                                    │
-        │   share: nil,                                                                           │
-        │   _isDeleted: false,                                                                    │
-        │   isShared: false,                                                                      │
-        │   userModificationDate: Date(1970-01-01T00:00:01.000Z)                                  │
-        │ )                                                                                       │
-        ├─────────────────────────────────────────────────────────────────────────────────────────┤
-        │ SyncMetadata(                                                                           │
-        │   recordPrimaryKey: "optional",                                                         │
-        │   recordType: "tags",                                                                   │
-        │   recordName: "optional:tags",                                                          │
-        │   parentRecordPrimaryKey: nil,                                                          │
-        │   parentRecordType: nil,                                                                │
-        │   parentRecordName: nil,                                                                │
-        │   lastKnownServerRecord: CKRecord(                                                      │
-        │     recordID: CKRecord.ID(optional:tags/zone/__defaultOwner__),                         │
-        │     recordType: "tags",                                                                 │
-        │     parent: nil,                                                                        │
-        │     share: nil                                                                          │
-        │   ),                                                                                    │
-        │   _lastKnownServerRecordAllFields: CKRecord(                                            │
-        │     recordID: CKRecord.ID(optional:tags/zone/__defaultOwner__),                         │
-        │     recordType: "tags",                                                                 │
-        │     parent: nil,                                                                        │
-        │     share: nil,                                                                         │
-        │     title: "optional"                                                                   │
-        │   ),                                                                                    │
-        │   share: nil,                                                                           │
-        │   _isDeleted: false,                                                                    │
-        │   isShared: false,                                                                      │
-        │   userModificationDate: Date(1970-01-01T00:00:01.000Z)                                  │
-        │ )                                                                                       │
-        └─────────────────────────────────────────────────────────────────────────────────────────┘
+        ┌────────────────────┐
+        │ "1:remindersLists" │
+        │ "1:reminders"      │
+        │ "1:reminderTags"   │
+        │ "optional:tags"    │
+        └────────────────────┘
         """
       }
       assertInlineSnapshot(of: container, as: .customDump) {

--- a/Tests/SharingGRDBTests/CloudKitTests/FetchRecordZoneChangesTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/FetchRecordZoneChangesTests.swift
@@ -4,6 +4,7 @@ import Foundation
 import InlineSnapshotTesting
 import OrderedCollections
 import SharingGRDB
+import SharingGRDBTestSupport
 import SnapshotTestingCustomDump
 import Testing
 
@@ -38,9 +39,9 @@ extension BaseCloudKitTests {
           """
           [
             [0]: CKRecord(
-              recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+              recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
               recordType: "reminders",
-              parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+              parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
               share: nil,
               id: 1,
               isCompleted: 0,
@@ -49,7 +50,7 @@ extension BaseCloudKitTests {
               title: "Get milk"
             ),
             [1]: CKRecord(
-              recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+              recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
               recordType: "remindersLists",
               parent: nil,
               share: nil,
@@ -81,9 +82,9 @@ extension BaseCloudKitTests {
             """
             [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 isCompleted: 1,
@@ -92,7 +93,7 @@ extension BaseCloudKitTests {
                 title: "Get milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -138,9 +139,9 @@ extension BaseCloudKitTests {
       ) {
         """
         CKRecord(
-          recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+          recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
           recordType: "reminders",
-          parent: CKReference(recordID: CKRecord.ID(2:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+          parent: CKReference(recordID: CKRecord.ID(2:remindersLists/zone/__defaultOwner__)),
           share: nil,
           id: 1,
           isCompleted: 0,
@@ -173,9 +174,9 @@ extension BaseCloudKitTests {
       ) {
         """
         CKRecord(
-          recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+          recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
           recordType: "reminders",
-          parent: CKReference(recordID: CKRecord.ID(2:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+          parent: CKReference(recordID: CKRecord.ID(2:remindersLists/zone/__defaultOwner__)),
           share: nil,
           id: 1,
           isCompleted: 0,
@@ -221,7 +222,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -264,7 +265,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -321,16 +322,16 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: "1",
                 remindersListID: "1",
                 title: "Get milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -386,9 +387,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 isCompleted: 0,
@@ -396,7 +397,7 @@ extension BaseCloudKitTests {
                 title: "Buy milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -480,6 +481,121 @@ extension BaseCloudKitTests {
       }
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
+      assertQuery(SyncMetadata.all, database: userDatabase.database) {
+        """
+        ┌─────────────────────────────────────────────────────────────────────────────────────────┐
+        │ SyncMetadata(                                                                           │
+        │   recordPrimaryKey: "1",                                                                │
+        │   recordType: "remindersLists",                                                         │
+        │   recordName: "1:remindersLists",                                                       │
+        │   parentRecordPrimaryKey: nil,                                                          │
+        │   parentRecordType: nil,                                                                │
+        │   parentRecordName: nil,                                                                │
+        │   lastKnownServerRecord: CKRecord(                                                      │
+        │     recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),                      │
+        │     recordType: "remindersLists",                                                       │
+        │     parent: nil,                                                                        │
+        │     share: nil                                                                          │
+        │   ),                                                                                    │
+        │   _lastKnownServerRecordAllFields: CKRecord(                                            │
+        │     recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),                      │
+        │     recordType: "remindersLists",                                                       │
+        │     parent: nil,                                                                        │
+        │     share: nil,                                                                         │
+        │     id: 1,                                                                              │
+        │     title: "Personal"                                                                   │
+        │   ),                                                                                    │
+        │   share: nil,                                                                           │
+        │   _isDeleted: false,                                                                    │
+        │   isShared: false,                                                                      │
+        │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+        │ )                                                                                       │
+        ├─────────────────────────────────────────────────────────────────────────────────────────┤
+        │ SyncMetadata(                                                                           │
+        │   recordPrimaryKey: "1",                                                                │
+        │   recordType: "reminders",                                                              │
+        │   recordName: "1:reminders",                                                            │
+        │   parentRecordPrimaryKey: "1",                                                          │
+        │   parentRecordType: "remindersLists",                                                   │
+        │   parentRecordName: "1:remindersLists",                                                 │
+        │   lastKnownServerRecord: CKRecord(                                                      │
+        │     recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),                           │
+        │     recordType: "reminders",                                                            │
+        │     parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)), │
+        │     share: nil                                                                          │
+        │   ),                                                                                    │
+        │   _lastKnownServerRecordAllFields: CKRecord(                                            │
+        │     recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),                           │
+        │     recordType: "reminders",                                                            │
+        │     parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)), │
+        │     share: nil,                                                                         │
+        │     id: 1,                                                                              │
+        │     isCompleted: 0,                                                                     │
+        │     remindersListID: 1,                                                                 │
+        │     title: "Get milk"                                                                   │
+        │   ),                                                                                    │
+        │   share: nil,                                                                           │
+        │   _isDeleted: false,                                                                    │
+        │   isShared: false,                                                                      │
+        │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                  │
+        │ )                                                                                       │
+        ├─────────────────────────────────────────────────────────────────────────────────────────┤
+        │ SyncMetadata(                                                                           │
+        │   recordPrimaryKey: "1",                                                                │
+        │   recordType: "reminderTags",                                                           │
+        │   recordName: "1:reminderTags",                                                         │
+        │   parentRecordPrimaryKey: nil,                                                          │
+        │   parentRecordType: nil,                                                                │
+        │   parentRecordName: nil,                                                                │
+        │   lastKnownServerRecord: CKRecord(                                                      │
+        │     recordID: CKRecord.ID(1:reminderTags/zone/__defaultOwner__),                        │
+        │     recordType: "reminderTags",                                                         │
+        │     parent: nil,                                                                        │
+        │     share: nil                                                                          │
+        │   ),                                                                                    │
+        │   _lastKnownServerRecordAllFields: CKRecord(                                            │
+        │     recordID: CKRecord.ID(1:reminderTags/zone/__defaultOwner__),                        │
+        │     recordType: "reminderTags",                                                         │
+        │     parent: nil,                                                                        │
+        │     share: nil,                                                                         │
+        │     id: 1,                                                                              │
+        │     reminderID: 1,                                                                      │
+        │     tagID: "optional"                                                                   │
+        │   ),                                                                                    │
+        │   share: nil,                                                                           │
+        │   _isDeleted: false,                                                                    │
+        │   isShared: false,                                                                      │
+        │   userModificationDate: Date(1970-01-01T00:00:01.000Z)                                  │
+        │ )                                                                                       │
+        ├─────────────────────────────────────────────────────────────────────────────────────────┤
+        │ SyncMetadata(                                                                           │
+        │   recordPrimaryKey: "optional",                                                         │
+        │   recordType: "tags",                                                                   │
+        │   recordName: "optional:tags",                                                          │
+        │   parentRecordPrimaryKey: nil,                                                          │
+        │   parentRecordType: nil,                                                                │
+        │   parentRecordName: nil,                                                                │
+        │   lastKnownServerRecord: CKRecord(                                                      │
+        │     recordID: CKRecord.ID(optional:tags/zone/__defaultOwner__),                         │
+        │     recordType: "tags",                                                                 │
+        │     parent: nil,                                                                        │
+        │     share: nil                                                                          │
+        │   ),                                                                                    │
+        │   _lastKnownServerRecordAllFields: CKRecord(                                            │
+        │     recordID: CKRecord.ID(optional:tags/zone/__defaultOwner__),                         │
+        │     recordType: "tags",                                                                 │
+        │     parent: nil,                                                                        │
+        │     share: nil,                                                                         │
+        │     title: "optional"                                                                   │
+        │   ),                                                                                    │
+        │   share: nil,                                                                           │
+        │   _isDeleted: false,                                                                    │
+        │   isShared: false,                                                                      │
+        │   userModificationDate: Date(1970-01-01T00:00:01.000Z)                                  │
+        │ )                                                                                       │
+        └─────────────────────────────────────────────────────────────────────────────────────────┘
+        """
+      }
       assertInlineSnapshot(of: container, as: .customDump) {
         """
         MockCloudContainer(
@@ -487,7 +603,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminderTags/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminderTags/zone/__defaultOwner__),
                 recordType: "reminderTags",
                 parent: nil,
                 share: nil,
@@ -496,9 +612,9 @@ extension BaseCloudKitTests {
                 tagID: "optional"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 isCompleted: 0,
@@ -506,7 +622,7 @@ extension BaseCloudKitTests {
                 title: "Get milk"
               ),
               [2]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -514,18 +630,11 @@ extension BaseCloudKitTests {
                 title: "Personal"
               ),
               [3]: CKRecord(
-                recordID: CKRecord.ID(optional:tags/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(optional:tags/zone/__defaultOwner__),
                 recordType: "tags",
                 parent: nil,
                 share: nil,
                 title: "optional"
-              ),
-              [4]: CKRecord(
-                recordID: CKRecord.ID(weekend:tags/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
-                recordType: "tags",
-                parent: nil,
-                share: nil,
-                title: "weekend"
               )
             ]
           ),

--- a/Tests/SharingGRDBTests/CloudKitTests/FetchedDatabaseChangesTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/FetchedDatabaseChangesTests.swift
@@ -83,9 +83,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 isCompleted: 0,
@@ -93,9 +93,9 @@ extension BaseCloudKitTests {
                 title: "Get milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(2:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(2:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(2:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(2:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 2,
                 isCompleted: 0,
@@ -103,25 +103,25 @@ extension BaseCloudKitTests {
                 title: "Call accountant"
               ),
               [2]: CKRecord(
-                recordID: CKRecord.ID(1:remindersListPrivates/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersListPrivates/zone/__defaultOwner__),
                 recordType: "remindersListPrivates",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 position: 0,
                 remindersListID: 1
               ),
               [3]: CKRecord(
-                recordID: CKRecord.ID(2:remindersListPrivates/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(2:remindersListPrivates/zone/__defaultOwner__),
                 recordType: "remindersListPrivates",
-                parent: CKReference(recordID: CKRecord.ID(2:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(2:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 2,
                 position: 0,
                 remindersListID: 2
               ),
               [4]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -129,7 +129,7 @@ extension BaseCloudKitTests {
                 title: "Personal"
               ),
               [5]: CKRecord(
-                recordID: CKRecord.ID(2:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(2:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,

--- a/Tests/SharingGRDBTests/CloudKitTests/ForeignKeyConstraintTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/ForeignKeyConstraintTests.swift
@@ -43,16 +43,16 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 remindersListID: 1,
                 title: "Get milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -115,9 +115,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 isCompleted: 0,
@@ -125,7 +125,7 @@ extension BaseCloudKitTests {
                 title: "Buy milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -193,7 +193,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:modelAs/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),
                 recordType: "modelAs",
                 parent: nil,
                 share: nil
@@ -254,16 +254,16 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 remindersListID: 1,
                 title: "Get milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -325,16 +325,16 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 remindersListID: 1,
                 title: "Get milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -406,9 +406,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 isCompleted: 0,
@@ -416,7 +416,7 @@ extension BaseCloudKitTests {
                 title: "Buy milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -484,16 +484,16 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 remindersListID: 1,
                 title: "Get milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -536,16 +536,16 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(2:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(2:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 remindersListID: 2,
                 title: "Get milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -553,7 +553,7 @@ extension BaseCloudKitTests {
                 title: "Personal"
               ),
               [2]: CKRecord(
-                recordID: CKRecord.ID(2:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(2:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -641,9 +641,9 @@ extension BaseCloudKitTests {
       ) {
         """
         CKRecord(
-          recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+          recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
           recordType: "reminders",
-          parent: CKReference(recordID: CKRecord.ID(3:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+          parent: CKReference(recordID: CKRecord.ID(3:remindersLists/zone/__defaultOwner__)),
           share: nil,
           id: 1,
           isCompleted: 0,
@@ -720,9 +720,9 @@ extension BaseCloudKitTests {
       ) {
         """
         CKRecord(
-          recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+          recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
           recordType: "reminders",
-          parent: CKReference(recordID: CKRecord.ID(3:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+          parent: CKReference(recordID: CKRecord.ID(3:remindersLists/zone/__defaultOwner__)),
           share: nil,
           id: 1,
           isCompleted: 0,
@@ -742,9 +742,9 @@ extension BaseCloudKitTests {
       ) {
         """
         CKRecord(
-          recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+          recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
           recordType: "reminders",
-          parent: CKReference(recordID: CKRecord.ID(3:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+          parent: CKReference(recordID: CKRecord.ID(3:remindersLists/zone/__defaultOwner__)),
           share: nil,
           id: 1,
           isCompleted: 0,
@@ -792,9 +792,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(3:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(3:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(3:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(3:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 3,
                 isCompleted: 0,
@@ -802,7 +802,7 @@ extension BaseCloudKitTests {
                 title: "Schedule secret meeting"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(3:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(3:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,

--- a/Tests/SharingGRDBTests/CloudKitTests/MergeConflictTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/MergeConflictTests.swift
@@ -26,9 +26,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 id🗓️: 0,
@@ -41,7 +41,7 @@ extension BaseCloudKitTests {
                 🗓️: 0
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -84,9 +84,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 id🗓️: 0,
@@ -99,7 +99,7 @@ extension BaseCloudKitTests {
                 🗓️: 60
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -129,9 +129,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 id🗓️: 0,
@@ -144,7 +144,7 @@ extension BaseCloudKitTests {
                 🗓️: 60
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -181,9 +181,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 id🗓️: 0,
@@ -196,7 +196,7 @@ extension BaseCloudKitTests {
                 🗓️: 0
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -239,9 +239,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 id🗓️: 0,
@@ -254,7 +254,7 @@ extension BaseCloudKitTests {
                 🗓️: 30
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -284,9 +284,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 id🗓️: 0,
@@ -299,7 +299,7 @@ extension BaseCloudKitTests {
                 🗓️: 60
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -354,9 +354,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 id🗓️: 0,
@@ -369,7 +369,7 @@ extension BaseCloudKitTests {
                 🗓️: 60
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -431,9 +431,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 id🗓️: 0,
@@ -446,7 +446,7 @@ extension BaseCloudKitTests {
                 🗓️: 60
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -501,9 +501,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 id🗓️: 0,
@@ -516,7 +516,7 @@ extension BaseCloudKitTests {
                 🗓️: 60
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -572,9 +572,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 id🗓️: 0,
@@ -587,7 +587,7 @@ extension BaseCloudKitTests {
                 🗓️: 60
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -649,9 +649,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 dueDate: Date(1970-01-01T00:00:30.000Z),
                 dueDate🗓️: 1,
@@ -668,7 +668,7 @@ extension BaseCloudKitTests {
                 🗓️: 2
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,

--- a/Tests/SharingGRDBTests/CloudKitTests/MetadataTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/MetadataTests.swift
@@ -28,9 +28,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 isCompleted: 0,
@@ -38,7 +38,7 @@ extension BaseCloudKitTests {
                 title: "Groceries"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -46,7 +46,7 @@ extension BaseCloudKitTests {
                 title: "Personal"
               ),
               [2]: CKRecord(
-                recordID: CKRecord.ID(2:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(2:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -98,9 +98,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(2:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(2:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 isCompleted: 0,
@@ -108,7 +108,7 @@ extension BaseCloudKitTests {
                 title: "Groceries"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -116,7 +116,7 @@ extension BaseCloudKitTests {
                 title: "Personal"
               ),
               [2]: CKRecord(
-                recordID: CKRecord.ID(2:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(2:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -153,7 +153,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminderTags/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminderTags/zone/__defaultOwner__),
                 recordType: "reminderTags",
                 parent: nil,
                 share: nil,
@@ -162,9 +162,9 @@ extension BaseCloudKitTests {
                 tagID: "weekend"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 isCompleted: 0,
@@ -172,7 +172,7 @@ extension BaseCloudKitTests {
                 title: "Groceries"
               ),
               [2]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -180,7 +180,7 @@ extension BaseCloudKitTests {
                 title: "Personal"
               ),
               [3]: CKRecord(
-                recordID: CKRecord.ID(weekend:tags/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(weekend:tags/zone/__defaultOwner__),
                 recordType: "tags",
                 parent: nil,
                 share: nil,

--- a/Tests/SharingGRDBTests/CloudKitTests/MockCloudDatabaseTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/MockCloudDatabaseTests.swift
@@ -140,7 +140,14 @@ extension BaseCloudKitTests {
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
             databaseScope: .private,
-            storage: []
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(Record/zone/__defaultOwner__),
+                recordType: "Record",
+                parent: nil,
+                share: nil
+              )
+            ]
           ),
           sharedCloudDatabase: MockCloudDatabase(
             databaseScope: .shared,

--- a/Tests/SharingGRDBTests/CloudKitTests/MockCloudDatabaseTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/MockCloudDatabaseTests.swift
@@ -30,7 +30,7 @@ extension BaseCloudKitTests {
         try self.syncEngine.private.database.record(
           for: CKRecord.ID(
             recordName: "A",
-            zoneID: CKRecordZone.ID(zoneName: "zone")
+            zoneID: CKRecordZone.ID(zoneName: "unknownZone")
           )
         )
       }
@@ -123,7 +123,7 @@ extension BaseCloudKitTests {
     @Test func saveInUnknownZone() async throws {
       let record = CKRecord(
         recordType: "Record",
-        recordID: CKRecord.ID(recordName: "Record", zoneID: CKRecordZone.ID(zoneName: "zone"))
+        recordID: CKRecord.ID(recordName: "Record", zoneID: CKRecordZone.ID(zoneName: "unknownZone"))
       )
 
       let (saveRecordResults, _) = try syncEngine.private.database.modifyRecords(
@@ -140,14 +140,7 @@ extension BaseCloudKitTests {
         MockCloudContainer(
           privateCloudDatabase: MockCloudDatabase(
             databaseScope: .private,
-            storage: [
-              [0]: CKRecord(
-                recordID: CKRecord.ID(Record/zone/__defaultOwner__),
-                recordType: "Record",
-                parent: nil,
-                share: nil
-              )
-            ]
+            storage: []
           ),
           sharedCloudDatabase: MockCloudDatabase(
             databaseScope: .shared,
@@ -215,7 +208,7 @@ extension BaseCloudKitTests {
     @Test func deleteRecordInUnknownZone() async throws {
       let record = CKRecord(
         recordType: "A",
-        recordID: CKRecord.ID(recordName: "A", zoneID: CKRecordZone.ID(zoneName: "zone"))
+        recordID: CKRecord.ID(recordName: "A", zoneID: CKRecordZone.ID(zoneName: "unknownZone"))
       )
 
       let (_, deleteResults) = try syncEngine.private.database.modifyRecords(
@@ -290,10 +283,10 @@ extension BaseCloudKitTests {
     @Test func deleteUnknownZone() async throws {
       let (_, deleteResults) = try syncEngine.private.database.modifyRecordZones(
         saving: [],
-        deleting: [CKRecordZone.ID(zoneName: "zone")]
+        deleting: [CKRecordZone.ID(zoneName: "unknownZone")]
       )
       let error = #expect(throws: CKError.self) {
-        try deleteResults[CKRecordZone.ID(zoneName: "zone")]?.get()
+        try deleteResults[CKRecordZone.ID(zoneName: "unknownZone")]?.get()
       }
       #expect(error == CKError(.zoneNotFound))
     }

--- a/Tests/SharingGRDBTests/CloudKitTests/NewTableSyncTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/NewTableSyncTests.swift
@@ -33,9 +33,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 isCompleted: 0,
@@ -43,7 +43,7 @@ extension BaseCloudKitTests {
                 title: "Write blog post"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -74,15 +74,15 @@ extension BaseCloudKitTests {
             parentRecordType: "remindersLists",
             parentRecordName: "1:remindersLists",
             lastKnownServerRecord: CKRecord(
-              recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+              recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
               recordType: "reminders",
-              parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+              parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
               share: nil
             ),
             _lastKnownServerRecordAllFields: CKRecord(
-              recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+              recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
               recordType: "reminders",
-              parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+              parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
               share: nil,
               id: 1,
               isCompleted: 0,
@@ -102,13 +102,13 @@ extension BaseCloudKitTests {
             parentRecordType: nil,
             parentRecordName: nil,
             lastKnownServerRecord: CKRecord(
-              recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+              recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
               recordType: "remindersLists",
               parent: nil,
               share: nil
             ),
             _lastKnownServerRecordAllFields: CKRecord(
-              recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+              recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
               recordType: "remindersLists",
               parent: nil,
               share: nil,

--- a/Tests/SharingGRDBTests/CloudKitTests/NextRecordZoneChangeBatchTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/NextRecordZoneChangeBatchTests.swift
@@ -108,7 +108,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -143,9 +143,9 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 isCompleted: 0,
@@ -153,7 +153,7 @@ extension BaseCloudKitTests {
                 title: "Get milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -188,16 +188,16 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersListPrivates/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersListPrivates/zone/__defaultOwner__),
                 recordType: "remindersListPrivates",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 position: 42,
                 remindersListID: 1
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,

--- a/Tests/SharingGRDBTests/CloudKitTests/ReferenceViolationTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/ReferenceViolationTests.swift
@@ -50,7 +50,7 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -123,16 +123,16 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                 recordType: "reminders",
-                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                 share: nil,
                 id: 1,
                 remindersListID: 1,
                 title: "Get milk"
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
                 share: nil,
@@ -199,36 +199,36 @@ extension BaseCloudKitTests {
       try await syncEngine.processPendingRecordZoneChanges(scope: .private)
 
       assertInlineSnapshot(of: container, as: .customDump) {
-          """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: [
-                [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
-                  recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
-                  share: nil,
-                  id: 1,
-                  remindersListID: 1,
-                  title: "Get milk"
-                ),
-                [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
-                  recordType: "remindersLists",
-                  parent: nil,
-                  share: nil,
-                  id: 1,
-                  title: "Personal"
-                )
-              ]
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
+        """
+        MockCloudContainer(
+          privateCloudDatabase: MockCloudDatabase(
+            databaseScope: .private,
+            storage: [
+              [0]: CKRecord(
+                recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
+                recordType: "reminders",
+                parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
+                share: nil,
+                id: 1,
+                remindersListID: 1,
+                title: "Get milk"
+              ),
+              [1]: CKRecord(
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
+                recordType: "remindersLists",
+                parent: nil,
+                share: nil,
+                id: 1,
+                title: "Personal"
+              )
+            ]
+          ),
+          sharedCloudDatabase: MockCloudDatabase(
+            databaseScope: .shared,
+            storage: []
           )
-          """
+        )
+        """
       }
 
       try await userDatabase.read { db in
@@ -281,14 +281,14 @@ extension BaseCloudKitTests {
               databaseScope: .private,
               storage: [
                 [0]: CKRecord(
-                  recordID: CKRecord.ID(1:childWithOnDeleteSetNulls/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(1:childWithOnDeleteSetNulls/zone/__defaultOwner__),
                   recordType: "childWithOnDeleteSetNulls",
                   parent: nil,
                   share: nil,
                   id: 1
                 ),
                 [1]: CKRecord(
-                  recordID: CKRecord.ID(1:parents/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(1:parents/zone/__defaultOwner__),
                   recordType: "parents",
                   parent: nil,
                   share: nil,
@@ -359,22 +359,22 @@ extension BaseCloudKitTests {
               databaseScope: .private,
               storage: [
                 [0]: CKRecord(
-                  recordID: CKRecord.ID(1:childWithOnDeleteSetDefaults/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(1:childWithOnDeleteSetDefaults/zone/__defaultOwner__),
                   recordType: "childWithOnDeleteSetDefaults",
-                  parent: CKReference(recordID: CKRecord.ID(0:parents/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                  parent: CKReference(recordID: CKRecord.ID(0:parents/zone/__defaultOwner__)),
                   share: nil,
                   id: 1,
                   parentID: 0
                 ),
                 [1]: CKRecord(
-                  recordID: CKRecord.ID(0:parents/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(0:parents/zone/__defaultOwner__),
                   recordType: "parents",
                   parent: nil,
                   share: nil,
                   id: 0
                 ),
                 [2]: CKRecord(
-                  recordID: CKRecord.ID(1:parents/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(1:parents/zone/__defaultOwner__),
                   recordType: "parents",
                   parent: nil,
                   share: nil,

--- a/Tests/SharingGRDBTests/CloudKitTests/SharingPermissionsTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/SharingPermissionsTests.swift
@@ -1,5 +1,6 @@
 import CloudKit
 import CustomDump
+import GRDB
 import Foundation
 import InlineSnapshotTesting
 import OrderedCollections

--- a/Tests/SharingGRDBTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/SharingTests.swift
@@ -490,16 +490,16 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(share-1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__),
                 recordType: "cloudkit.share",
                 parent: nil,
                 share: nil
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
-                share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__))
+                share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__))
               )
             ]
           ),
@@ -552,10 +552,10 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
-                share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__))
+                share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__))
               )
             ]
           ),
@@ -576,16 +576,16 @@ extension BaseCloudKitTests {
             databaseScope: .private,
             storage: [
               [0]: CKRecord(
-                recordID: CKRecord.ID(share-1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__),
                 recordType: "cloudkit.share",
                 parent: nil,
                 share: nil
               ),
               [1]: CKRecord(
-                recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                 recordType: "remindersLists",
                 parent: nil,
-                share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__))
+                share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__))
               )
             ]
           ),

--- a/Tests/SharingGRDBTests/CloudKitTests/SyncEngineLifecycleTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/SyncEngineLifecycleTests.swift
@@ -62,9 +62,9 @@ extension BaseCloudKitTests {
               databaseScope: .private,
               storage: [
                 [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                   recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                   share: nil,
                   id: 1,
                   isCompleted: 0,
@@ -72,7 +72,7 @@ extension BaseCloudKitTests {
                   title: "Get milk"
                 ),
                 [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                   recordType: "remindersLists",
                   parent: nil,
                   share: nil,
@@ -160,7 +160,7 @@ extension BaseCloudKitTests {
                 databaseScope: .private,
                 storage: [
                   [0]: CKRecord(
-                    recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                    recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                     recordType: "remindersLists",
                     parent: nil,
                     share: nil,
@@ -316,16 +316,16 @@ extension BaseCloudKitTests {
               databaseScope: .private,
               storage: [
                 [0]: CKRecord(
-                  recordID: CKRecord.ID(share-1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__),
                   recordType: "cloudkit.share",
                   parent: nil,
                   share: nil
                 ),
                 [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                   recordType: "remindersLists",
                   parent: nil,
-                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__))
+                  share: CKReference(recordID: CKRecord.ID(share-1:remindersLists/zone/__defaultOwner__))
                 )
               ]
             ),
@@ -417,9 +417,9 @@ extension BaseCloudKitTests {
               databaseScope: .private,
               storage: [
                 [0]: CKRecord(
-                  recordID: CKRecord.ID(1:reminders/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(1:reminders/zone/__defaultOwner__),
                   recordType: "reminders",
-                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__)),
+                  parent: CKReference(recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__)),
                   share: nil,
                   id: 1,
                   isCompleted: 0,
@@ -427,7 +427,7 @@ extension BaseCloudKitTests {
                   title: "Get milk"
                 ),
                 [1]: CKRecord(
-                  recordID: CKRecord.ID(1:remindersLists/co.pointfree.SQLiteData.defaultZone/__defaultOwner__),
+                  recordID: CKRecord.ID(1:remindersLists/zone/__defaultOwner__),
                   recordType: "remindersLists",
                   parent: nil,
                   share: nil,

--- a/Tests/SharingGRDBTests/CloudKitTests/TriggerTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/TriggerTests.swift
@@ -702,6 +702,258 @@ extension BaseCloudKitTests {
             END
             """,
             [39]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_childWithOnDeleteSetDefaults"
+            AFTER UPDATE OF "id" ON "childWithOnDeleteSetDefaults"
+            FOR EACH ROW WHEN ("old"."id" <> "new"."id") BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."parentID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'parents'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "_isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'childWithOnDeleteSetDefaults'));
+            END
+            """,
+            [40]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_childWithOnDeleteSetNulls"
+            AFTER UPDATE OF "id" ON "childWithOnDeleteSetNulls"
+            FOR EACH ROW WHEN ("old"."id" <> "new"."id") BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."parentID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'parents'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "_isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'childWithOnDeleteSetNulls'));
+            END
+            """,
+            [41]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_modelAs"
+            AFTER UPDATE OF "id" ON "modelAs"
+            FOR EACH ROW WHEN ("old"."id" <> "new"."id") BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "_isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelAs'));
+            END
+            """,
+            [42]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_modelBs"
+            AFTER UPDATE OF "id" ON "modelBs"
+            FOR EACH ROW WHEN ("old"."id" <> "new"."id") BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."modelAID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'modelAs'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "_isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelBs'));
+            END
+            """,
+            [43]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_modelCs"
+            AFTER UPDATE OF "id" ON "modelCs"
+            FOR EACH ROW WHEN ("old"."id" <> "new"."id") BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."modelBID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'modelBs'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "_isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'modelCs'));
+            END
+            """,
+            [44]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_parents"
+            AFTER UPDATE OF "id" ON "parents"
+            FOR EACH ROW WHEN ("old"."id" <> "new"."id") BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "_isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'parents'));
+            END
+            """,
+            [45]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_reminderTags"
+            AFTER UPDATE OF "id" ON "reminderTags"
+            FOR EACH ROW WHEN ("old"."id" <> "new"."id") BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "_isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminderTags'));
+            END
+            """,
+            [46]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_reminders"
+            AFTER UPDATE OF "id" ON "reminders"
+            FOR EACH ROW WHEN ("old"."id" <> "new"."id") BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."remindersListID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'remindersLists'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "_isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'reminders'));
+            END
+            """,
+            [47]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_remindersListAssets"
+            AFTER UPDATE OF "id" ON "remindersListAssets"
+            FOR EACH ROW WHEN ("old"."id" <> "new"."id") BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."remindersListID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'remindersLists'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "_isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersListAssets'));
+            END
+            """,
+            [48]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_remindersListPrivates"
+            AFTER UPDATE OF "id" ON "remindersListPrivates"
+            FOR EACH ROW WHEN ("old"."id" <> "new"."id") BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."remindersListID") AND ("sqlitedata_icloud_metadata"."recordType" IS 'remindersLists'))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "_isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersListPrivates'));
+            END
+            """,
+            [49]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_remindersLists"
+            AFTER UPDATE OF "id" ON "remindersLists"
+            FOR EACH ROW WHEN ("old"."id" <> "new"."id") BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "_isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."id") AND ("sqlitedata_icloud_metadata"."recordType" = 'remindersLists'));
+            END
+            """,
+            [50]: """
+            CREATE TRIGGER "sqlitedata_icloud_after_primary_key_change_on_tags"
+            AFTER UPDATE OF "title" ON "tags"
+            FOR EACH ROW WHEN ("old"."title" <> "new"."title") BEGIN
+              WITH "rootShares" AS (
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS NULL) AND ("sqlitedata_icloud_metadata"."recordType" IS NULL))
+                  UNION ALL
+                SELECT "sqlitedata_icloud_metadata"."parentRecordName" AS "parentRecordName", "sqlitedata_icloud_metadata"."share" AS "share"
+                FROM "sqlitedata_icloud_metadata"
+                JOIN "rootShares" ON ("sqlitedata_icloud_metadata"."recordName" IS "rootShares"."parentRecordName")
+              )
+              SELECT RAISE(ABORT, 'co.pointfree.sqlitedata-icloud.write-permission-error')
+              FROM "rootShares"
+              WHERE ((NOT (sqlitedata_icloud_syncEngineIsSynchronizingChanges()) AND ("rootShares"."parentRecordName" IS NULL)) AND NOT (sqlitedata_icloud_hasPermission("rootShares"."share")));
+              UPDATE "sqlitedata_icloud_metadata"
+              SET "_isDeleted" = 1
+              WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" = "old"."title") AND ("sqlitedata_icloud_metadata"."recordType" = 'tags'));
+            END
+            """,
+            [51]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_childWithOnDeleteSetDefaults"
             AFTER UPDATE ON "childWithOnDeleteSetDefaults"
             FOR EACH ROW BEGIN
@@ -724,7 +976,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [40]: """
+            [52]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_childWithOnDeleteSetNulls"
             AFTER UPDATE ON "childWithOnDeleteSetNulls"
             FOR EACH ROW BEGIN
@@ -747,7 +999,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [41]: """
+            [53]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_modelAs"
             AFTER UPDATE ON "modelAs"
             FOR EACH ROW BEGIN
@@ -770,7 +1022,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [42]: """
+            [54]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_modelBs"
             AFTER UPDATE ON "modelBs"
             FOR EACH ROW BEGIN
@@ -793,7 +1045,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [43]: """
+            [55]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_modelCs"
             AFTER UPDATE ON "modelCs"
             FOR EACH ROW BEGIN
@@ -816,7 +1068,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [44]: """
+            [56]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_parents"
             AFTER UPDATE ON "parents"
             FOR EACH ROW BEGIN
@@ -839,7 +1091,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [45]: """
+            [57]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_reminderTags"
             AFTER UPDATE ON "reminderTags"
             FOR EACH ROW BEGIN
@@ -862,7 +1114,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [46]: """
+            [58]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_reminders"
             AFTER UPDATE ON "reminders"
             FOR EACH ROW BEGIN
@@ -885,7 +1137,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [47]: """
+            [59]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_remindersListAssets"
             AFTER UPDATE ON "remindersListAssets"
             FOR EACH ROW BEGIN
@@ -908,7 +1160,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [48]: """
+            [60]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_remindersListPrivates"
             AFTER UPDATE ON "remindersListPrivates"
             FOR EACH ROW BEGIN
@@ -931,7 +1183,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [49]: """
+            [61]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_remindersLists"
             AFTER UPDATE ON "remindersLists"
             FOR EACH ROW BEGIN
@@ -954,7 +1206,7 @@ extension BaseCloudKitTests {
               DO UPDATE SET "parentRecordPrimaryKey" = "excluded"."parentRecordPrimaryKey", "parentRecordType" = "excluded"."parentRecordType", "userModificationDate" = "excluded"."userModificationDate";
             END
             """,
-            [50]: """
+            [62]: """
             CREATE TRIGGER "sqlitedata_icloud_after_update_on_tags"
             AFTER UPDATE ON "tags"
             FOR EACH ROW BEGIN

--- a/Tests/SharingGRDBTests/Internal/BaseCloudKitTests.swift
+++ b/Tests/SharingGRDBTests/Internal/BaseCloudKitTests.swift
@@ -141,7 +141,7 @@ extension SyncEngine {
     syncEngines.shared as! MockSyncEngine
   }
   static nonisolated let defaultTestZone = CKRecordZone(
-    zoneName: "co.pointfree.SQLiteData.defaultZone"
+    zoneName: "zone"
   )
   convenience init(
     container: any CloudContainer,


### PR DESCRIPTION
If we detect that someone has changed the primary key of a row (which should be rare, but can happen), we need to be sure to delete the record in CloudKit with the old primary key.