### PR TITLE
Lots of updates to docs.

### DIFF
--- a/Sources/SharingGRDBCore/Internal/Exports.swift
+++ b/Sources/SharingGRDBCore/Internal/Exports.swift
@@ -2,11 +2,12 @@
 @_exported import Sharing
 @_exported import StructuredQueriesGRDBCore
 
+@_exported import struct GRDB.Configuration
 @_exported import class GRDB.Database
+@_exported import struct GRDB.DatabaseError
+@_exported import struct GRDB.DatabaseMigrator
 @_exported import class GRDB.DatabasePool
 @_exported import class GRDB.DatabaseQueue
 @_exported import protocol GRDB.DatabaseReader
 @_exported import protocol GRDB.DatabaseWriter
 @_exported import protocol GRDB.ValueObservationScheduler
-@_exported import struct GRDB.Configuration
-@_exported import struct GRDB.DatabaseMigrator

--- a/Tests/SharingGRDBTests/CloudKitTests/SharingPermissionsTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/SharingPermissionsTests.swift
@@ -1,5 +1,6 @@
 import CloudKit
 import CustomDump
+import GRDB
 import Foundation
 import InlineSnapshotTesting
 import OrderedCollections

--- a/Tests/SharingGRDBTests/CloudKitTests/SyncEngineValidationTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/SyncEngineValidationTests.swift
@@ -61,7 +61,7 @@ extension BaseCloudKitTests {
             .execute(db)
             try #sql(
               """
-              CREATE TABLE "children" (
+              CREATE TABLE "childs" (
                 "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
                 "parentID" INTEGER REFERENCES "parents"("id") ON DELETE NO ACTION
               ) STRICT
@@ -76,7 +76,7 @@ extension BaseCloudKitTests {
               sharedCloudDatabase: MockCloudDatabase(databaseScope: .shared)
             ),
             userDatabase: UserDatabase(database: database),
-            tables: []
+            tables: [Child.self, Parent.self]
           )
         }
       )
@@ -98,7 +98,7 @@ extension BaseCloudKitTests {
               notnull: false
             )
           ),
-          debugDescription: #"Foreign key "children"."parentID" action not supported. Must be 'CASCADE', 'SET DEFAULT' or 'SET NULL'."#
+          debugDescription: #"Foreign key "childs"."parentID" action not supported. Must be 'CASCADE', 'SET DEFAULT' or 'SET NULL'."#
         )
         """
       }
@@ -120,7 +120,7 @@ extension BaseCloudKitTests {
             .execute(db)
             try #sql(
               """
-              CREATE TABLE "children" (
+              CREATE TABLE "childs" (
                 "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
                 "parentID" INTEGER REFERENCES "parents"("id") ON DELETE RESTRICT
               ) STRICT
@@ -135,7 +135,7 @@ extension BaseCloudKitTests {
               sharedCloudDatabase: MockCloudDatabase(databaseScope: .shared)
             ),
             userDatabase: UserDatabase(database: database),
-            tables: []
+            tables: [Parent.self, Child.self]
           )
         }
       )
@@ -157,7 +157,7 @@ extension BaseCloudKitTests {
               notnull: false
             )
           ),
-          debugDescription: #"Foreign key "children"."parentID" action not supported. Must be 'CASCADE', 'SET DEFAULT' or 'SET NULL'."#
+          debugDescription: #"Foreign key "childs"."parentID" action not supported. Must be 'CASCADE', 'SET DEFAULT' or 'SET NULL'."#
         )
         """
       }

--- a/Tests/SharingGRDBTests/CloudKitTests/SyncEngineValidationTests.swift
+++ b/Tests/SharingGRDBTests/CloudKitTests/SyncEngineValidationTests.swift
@@ -49,9 +49,7 @@ extension BaseCloudKitTests {
     @Test func foreignKeyActionValidation_NoAction() async throws {
       let error = try #require(
         await #expect(throws: (any Error).self) {
-          var configuration = Configuration()
-          configuration.foreignKeysEnabled = false
-          let database = try DatabaseQueue(configuration: configuration)
+          let database = try DatabaseQueue()
           try await database.write { db in
             try #sql(
               """
@@ -110,9 +108,7 @@ extension BaseCloudKitTests {
     @Test func foreignKeyActionValidation_Restrict() async throws {
       let error = try #require(
         await #expect(throws: (any Error).self) {
-          var configuration = Configuration()
-          configuration.foreignKeysEnabled = false
-          let database = try DatabaseQueue(configuration: configuration)
+          let database = try DatabaseQueue()
           try await database.write { db in
             try #sql(
               """
@@ -212,6 +208,53 @@ extension BaseCloudKitTests {
         userDatabase: UserDatabase(database: database),
         tables: []
       )
+    }
+
+    @Table struct ModelWithUniqueColumn {
+      let id: Int
+      let uniqueValue: Int
+    }
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func uniquenessConstraint() async throws {
+      let error = try #require(
+        await #expect(throws: (any Error).self) {
+          let database = try DatabaseQueue()
+          try await database.write { db in
+            try #sql(
+              """
+              CREATE TABLE "modelWithUniqueColumns" (
+                "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "uniqueValue" INTEGER NOT NULL,
+                UNIQUE("uniqueValue")
+              ) STRICT
+              """
+            )
+            .execute(db)
+          }
+          _ = try await SyncEngine(
+            container: MockCloudContainer(
+              containerIdentifier: "deadbeef",
+              privateCloudDatabase: MockCloudDatabase(databaseScope: .private),
+              sharedCloudDatabase: MockCloudDatabase(databaseScope: .shared)
+            ),
+            userDatabase: UserDatabase(database: database),
+            tables: [ModelWithUniqueColumn.self]
+          )
+        }
+      )
+      assertInlineSnapshot(of: error.localizedDescription, as: .customDump) {
+        """
+        "Could not synchronize data with iCloud."
+        """
+      }
+      assertInlineSnapshot(of: error, as: .customDump) {
+        """
+        SyncEngine.SchemaError(
+          reason: .uniquenessConstraint,
+          debugDescription: "Uniqueness constraints are not supported for synchronized tables."
+        )
+        """
+      }
     }
   }
 }


### PR DESCRIPTION
Updated a bunch of docs and along the way made a few fixes/improvements:

* We now enforce that uniqueness constraints cannot be used on non-primary key tables. I think we have no choice but to enforce this.
* I removed the only place we use `@Dependency(\.defaultSyncEngine)` within the library which makes it possible for people to run multiple sync engines if they want.
