### PR TITLE
Throw error when changing zones for existing record

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5f7df83a450ddad2662622f41356bb1fb40d7774f6d1e85438ffac479b93045a",
+  "originHash" : "32f70dab99ea92a018a46453e9ed1e8bbf1e5d17b2993ba8abc63cae49896bbc",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "1b653aba57486afef66d8aafdbe83246249118fd",
-        "version" : "0.19.0"
+        "revision" : "f576582c138311e442c564bd7a893e950765e46a",
+        "version" : "0.19.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.4"),
     .package(
       url: "https://github.com/pointfreeco/swift-structured-queries",
-      from: "0.19.0",
+      from: "0.19.1",
       traits: [
         .trait(name: "StructuredQueriesTagged", condition: .when(traits: ["SQLiteDataTagged"]))
       ]

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -27,7 +27,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", from: "2.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.4"),
-    .package(url: "https://github.com/pointfreeco/swift-structured-queries", from: "0.19.0"),
+    .package(url: "https://github.com/pointfreeco/swift-structured-queries", from: "0.19.1"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.5.0"),
   ],
   targets: [

--- a/Sources/SQLiteData/CloudKit/Internal/CloudKitFunctions.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/CloudKitFunctions.swift
@@ -10,7 +10,8 @@
 
   @DatabaseFunction(
     "sqlitedata_icloud_hasPermission",
-    as: ((CKShare?.SystemFieldsRepresentation) -> Bool).self
+    as: ((CKShare?.SystemFieldsRepresentation) -> Bool).self,
+    isDeterministic: true
   )
   func hasPermission(_ share: CKShare?) -> Bool {
     guard let share else { return true }

--- a/Sources/SQLiteData/CloudKit/Internal/Triggers.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Triggers.swift
@@ -148,7 +148,6 @@
               lastKnownServerRecord: new.lastKnownServerRecord
                 ?? rootServerRecord(recordName: new.recordName),
               newParentLastKnownServerRecord: parentLastKnownServerRecordIfShared(
-                recordName: new.recordName,
                 parentRecordPrimaryKey: new.parentRecordPrimaryKey,
                 parentRecordType: new.parentRecordType
               ),
@@ -175,7 +174,6 @@
               lastKnownServerRecord: new.lastKnownServerRecord
                 ?? rootServerRecord(recordName: new.recordName),
               newParentLastKnownServerRecord: parentLastKnownServerRecordIfShared(
-                recordName: new.recordName,
                 parentRecordPrimaryKey: new.parentRecordPrimaryKey,
                 parentRecordType: new.parentRecordType
               ),
@@ -297,7 +295,6 @@
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   private func parentLastKnownServerRecordIfShared(
-    recordName: some QueryExpression<String>,
     parentRecordPrimaryKey: some QueryExpression<String?>,
     parentRecordType: some QueryExpression<String?>
   ) -> some QueryExpression<CKRecord?.SystemFieldsRepresentation> {
@@ -313,7 +310,6 @@
   extension AncestorMetadata.Columns {
     init(_ metadata: SyncMetadata.TableColumns) {
       self.init(
-        isShared: metadata.isShared,
         recordName: metadata.recordName,
         parentRecordName: metadata.parentRecordName,
         lastKnownServerRecord: metadata.lastKnownServerRecord

--- a/Sources/SQLiteData/CloudKit/Internal/Triggers.swift
+++ b/Sources/SQLiteData/CloudKit/Internal/Triggers.swift
@@ -147,8 +147,7 @@
               recordName: new.recordName,
               lastKnownServerRecord: new.lastKnownServerRecord
                 ?? rootServerRecord(recordName: new.recordName),
-              newParentLastKnownServerRecord: #bind(nil),
-              childrenLastKnownServerRecordNames: #bind([])
+              newParentLastKnownServerRecord: #bind(nil)
             )
           )
         } when: { _ in
@@ -172,9 +171,6 @@
               newParentLastKnownServerRecord: parentLastKnownServerRecordIfShared(
                 recordName: new.recordName,
                 parentRecordName: new.parentRecordName
-              ),
-              childrenLastKnownServerRecordNames: childrenLastKnownServerRecordNamesIfShared(
-                recordName: new.recordName
               )
             )
           )
@@ -322,33 +318,6 @@
         $0.recordName.is(parentRecordName)
           && hasSharedAncestor(recordName: recordName)
       }
-  }
-
-@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  private func childrenLastKnownServerRecordNamesIfShared(
-    recordName: some QueryExpression<String>
-  ) -> some QueryExpression<[String].JSONRepresentation> {
-    With {
-      SyncMetadata
-        .where { $0.recordName.eq(recordName) }
-        .select { ChildMetadata.Columns(recordName: $0.recordName, parentRecordName: #bind(nil)) }
-        .union(all: true,
-          SyncMetadata
-            .select {
-              ChildMetadata.Columns(
-                recordName: $0.recordName,
-                parentRecordName: $0.parentRecordName
-              )
-            }
-            .join(ChildMetadata.all) { $0.parentRecordName.eq($1.recordName) }
-        )
-    } query: {
-      ChildMetadata
-        .where { $0.recordName.neq(recordName) }
-        .select {
-          $0.recordName.jsonGroupArray()
-        }
-    }
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -610,13 +610,21 @@
       let zoneID = lastKnownServerRecord?.recordID.zoneID ?? defaultZone.zoneID
       let newZoneID = newParentLastKnownServerRecord?.recordID.zoneID
       if let newZoneID, zoneID != newZoneID {
-        reportIssue("""
-          The record '\(recordName)' was moved from zone \
-          '\(zoneID.zoneName)/\(zoneID.ownerName)' to \
-          '\(newZoneID.zoneName)/\(newZoneID.ownerName)'. This is currently not supported in \
-          SQLiteData. To work around, delete the record and then create a new record with its \
-          new parent association.
-          """)
+        struct ZoneChangingError: Error, LocalizedError {
+          let recordName: String
+          let zoneID: CKRecordZone.ID
+          let newZoneID: CKRecordZone.ID
+          var errorDescription: String? {
+            """
+            The record '\(recordName)' was moved from zone \
+            '\(zoneID.zoneName)/\(zoneID.ownerName)' to \
+            '\(newZoneID.zoneName)/\(newZoneID.ownerName)'. This is currently not supported in \
+            SQLiteData. To work around, delete the record and then create a new record with its \
+            new parent association.
+            """
+          }
+        }
+        throw ZoneChangingError(recordName: recordName, zoneID: zoneID, newZoneID: newZoneID)
       }
 
       let change = CKSyncEngine.PendingRecordZoneChange.saveRecord(

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -597,13 +597,15 @@
     @DatabaseFunction(
       "sqlitedata_icloud_didUpdate",
       as: (
-        (String, CKRecord?.SystemFieldsRepresentation, CKRecord?.SystemFieldsRepresentation) -> Void
+        (String, CKRecord?.SystemFieldsRepresentation, CKRecord?.SystemFieldsRepresentation, String?, String?) -> Void
       ).self
     )
     func didUpdate(
       recordName: String,
       lastKnownServerRecord: CKRecord?,
-      newParentLastKnownServerRecord: CKRecord?
+      newParentLastKnownServerRecord: CKRecord?,
+      parentRecordPrimaryKey: String? = nil,
+      parentRecordType: String? = nil
     ) throws {
       let oldZoneID = lastKnownServerRecord?.recordID.zoneID ?? defaultZone.zoneID
       let newZoneID = newParentLastKnownServerRecord?.recordID.zoneID ?? defaultZone.zoneID

--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -607,30 +607,18 @@
       parentRecordPrimaryKey: String? = nil,
       parentRecordType: String? = nil
     ) throws {
-      let oldZoneID = lastKnownServerRecord?.recordID.zoneID ?? defaultZone.zoneID
-      let newZoneID = newParentLastKnownServerRecord?.recordID.zoneID ?? defaultZone.zoneID
-      guard oldZoneID == newZoneID else {
-        struct RecordChangedZonesError: LocalizedError {
-          let recordName: String
-          let oldZoneID: CKRecordZone.ID
-          let newZoneID: CKRecordZone.ID
-          var errorDescription: String? {
-            """
-            The record '\(recordName)' was moved from zone \
-            '\(oldZoneID.zoneName)/\(oldZoneID.ownerName)' to \
-            '\(newZoneID.zoneName)/\(newZoneID.ownerName)'. This is currently not supported in \
-            SQLiteData. To work around, delete the old record and create a new record.
-            """
-          }
-        }
-        throw RecordChangedZonesError(
-          recordName: recordName,
-          oldZoneID: oldZoneID,
-          newZoneID: newZoneID
-        )
+      let zoneID = lastKnownServerRecord?.recordID.zoneID ?? defaultZone.zoneID
+      let newZoneID = newParentLastKnownServerRecord?.recordID.zoneID
+      if let newZoneID, zoneID != newZoneID {
+        reportIssue("""
+          The record '\(recordName)' was moved from zone \
+          '\(zoneID.zoneName)/\(zoneID.ownerName)' to \
+          '\(newZoneID.zoneName)/\(newZoneID.ownerName)'. This is currently not supported in \
+          SQLiteData. To work around, delete the record and then create a new record with its \
+          new parent association.
+          """)
       }
 
-      let zoneID = lastKnownServerRecord?.recordID.zoneID ?? defaultZone.zoneID
       let change = CKSyncEngine.PendingRecordZoneChange.saveRecord(
         CKRecord.ID(
           recordName: recordName,

--- a/Sources/SQLiteData/CloudKit/SyncMetadata.swift
+++ b/Sources/SQLiteData/CloudKit/SyncMetadata.swift
@@ -82,18 +82,10 @@
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   @Table @Selection
   struct AncestorMetadata {
-    let isShared: Bool
     let recordName: String
     let parentRecordName: String?
     @Column(as: CKRecord?.SystemFieldsRepresentation.self)
     let lastKnownServerRecord: CKRecord?
-  }
-
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-  @Table @Selection
-  struct ChildMetadata {
-    let recordName: String
-    let parentRecordName: String?
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)

--- a/Sources/SQLiteData/CloudKit/SyncMetadata.swift
+++ b/Sources/SQLiteData/CloudKit/SyncMetadata.swift
@@ -66,7 +66,7 @@
 
     @Column(generated: .virtual)
     public let hasLastKnownServerRecord: Bool
-    
+
     /// Determines if the record associated with this metadata is currently shared in CloudKit.
     ///
     /// This can only return `true` for root records. For example, the metadata associated with a
@@ -82,10 +82,18 @@
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
   @Table @Selection
   struct AncestorMetadata {
+    let isShared: Bool
     let recordName: String
     let parentRecordName: String?
     @Column(as: CKRecord?.SystemFieldsRepresentation.self)
     let lastKnownServerRecord: CKRecord?
+  }
+
+  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  @Table @Selection
+  struct ChildMetadata {
+    let recordName: String
+    let parentRecordName: String?
   }
 
   @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)

--- a/Tests/SQLiteDataTests/CloudKitTests/NextRecordZoneChangeBatchTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/NextRecordZoneChangeBatchTests.swift
@@ -10,28 +10,28 @@
   extension BaseCloudKitTests {
     @MainActor
     final class NextRecordZoneChangeBatchTests: BaseCloudKitTests, @unchecked Sendable {
-      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-      @Test func noMetadataForRecord() async throws {
-        syncEngine.private.state.add(
-          pendingRecordZoneChanges: [.saveRecord(Reminder.recordID(for: 1))]
-        )
-
-        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-        assertInlineSnapshot(of: container, as: .customDump) {
-          """
-          MockCloudContainer(
-            privateCloudDatabase: MockCloudDatabase(
-              databaseScope: .private,
-              storage: []
-            ),
-            sharedCloudDatabase: MockCloudDatabase(
-              databaseScope: .shared,
-              storage: []
-            )
-          )
-          """
-        }
-      }
+//      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+//      @Test func noMetadataForRecord() async throws {
+//        syncEngine.private.state.add(
+//          pendingRecordZoneChanges: [.saveRecord(Reminder.recordID(for: 1))]
+//        )
+//
+//        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+//        assertInlineSnapshot(of: container, as: .customDump) {
+//          """
+//          MockCloudContainer(
+//            privateCloudDatabase: MockCloudDatabase(
+//              databaseScope: .private,
+//              storage: []
+//            ),
+//            sharedCloudDatabase: MockCloudDatabase(
+//              databaseScope: .shared,
+//              storage: []
+//            )
+//          )
+//          """
+//        }
+//      }
 
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func nonExistentTable() async throws {

--- a/Tests/SQLiteDataTests/CloudKitTests/NextRecordZoneChangeBatchTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/NextRecordZoneChangeBatchTests.swift
@@ -10,28 +10,28 @@
   extension BaseCloudKitTests {
     @MainActor
     final class NextRecordZoneChangeBatchTests: BaseCloudKitTests, @unchecked Sendable {
-//      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-//      @Test func noMetadataForRecord() async throws {
-//        syncEngine.private.state.add(
-//          pendingRecordZoneChanges: [.saveRecord(Reminder.recordID(for: 1))]
-//        )
-//
-//        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-//        assertInlineSnapshot(of: container, as: .customDump) {
-//          """
-//          MockCloudContainer(
-//            privateCloudDatabase: MockCloudDatabase(
-//              databaseScope: .private,
-//              storage: []
-//            ),
-//            sharedCloudDatabase: MockCloudDatabase(
-//              databaseScope: .shared,
-//              storage: []
-//            )
-//          )
-//          """
-//        }
-//      }
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func noMetadataForRecord() async throws {
+        syncEngine.private.state.add(
+          pendingRecordZoneChanges: [.saveRecord(Reminder.recordID(for: 1))]
+        )
+
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+        assertInlineSnapshot(of: container, as: .customDump) {
+          """
+          MockCloudContainer(
+            privateCloudDatabase: MockCloudDatabase(
+              databaseScope: .private,
+              storage: []
+            ),
+            sharedCloudDatabase: MockCloudDatabase(
+              databaseScope: .shared,
+              storage: []
+            )
+          )
+          """
+        }
+      }
 
       @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
       @Test func nonExistentTable() async throws {

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -909,6 +909,169 @@
           """
         }
       }
+
+//      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+//      @Test func movesChildRecordFromPrivateParentToSharedParent() async throws {
+//        try await userDatabase.userWrite { db in
+//          try db.seed {
+//            ModelA.Draft(id: 1, count: 42)
+//            ModelB.Draft(id: 1, isOn: true, modelAID: 1)
+//            ModelC.Draft(id: 1, title: "Blob", modelBID: 1)
+//            ModelC.Draft(id: 2, title: "Blob Jr", modelBID: 1)
+//            ModelC.Draft(id: 3, title: "Blob Sr", modelBID: 1)
+//          }
+//        }
+//        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+//
+//        let externalZone = CKRecordZone(
+//          zoneID: CKRecordZone.ID(
+//            zoneName: "external.zone",
+//            ownerName: "external.owner"
+//          )
+//        )
+//        try await syncEngine.modifyRecordZones(scope: .shared, saving: [externalZone]).notify()
+//
+//        let modelARecord = CKRecord(
+//          recordType: ModelA.tableName,
+//          recordID: ModelA.recordID(for: 2, zoneID: externalZone.zoneID)
+//        )
+//        modelARecord.setValue(2, forKey: "id", at: now)
+//        modelARecord.setValue(1729, forKey: "count", at: now)
+//        let share = CKShare(
+//          rootRecord: modelARecord,
+//          shareID: CKRecord.ID(
+//            recordName: "share-\(modelARecord.recordID.recordName)",
+//            zoneID: modelARecord.recordID.zoneID
+//          )
+//        )
+//        _ = try syncEngine.modifyRecords(scope: .shared, saving: [share, modelARecord])
+//        let freshShare = try syncEngine.shared.database.record(for: share.recordID) as! CKShare
+//        let freshModelARecord = try syncEngine.shared.database.record(for: modelARecord.recordID)
+//
+//        try await syncEngine
+//          .acceptShare(
+//            metadata: ShareMetadata(
+//              containerIdentifier: container.containerIdentifier!,
+//              hierarchicalRootRecordID: freshModelARecord.recordID,
+//              rootRecord: freshModelARecord,
+//              share: freshShare
+//            )
+//          )
+//
+//        try await userDatabase.userWrite { db in
+//          try ModelB.find(1).update { $0.modelAID = 2 }.execute(db)
+//        }
+//        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+//        try await syncEngine.processPendingRecordZoneChanges(scope: .shared)
+//
+//        assertQuery(ModelA.all, database: userDatabase.database)
+//        assertQuery(ModelB.all, database: userDatabase.database)
+//        assertQuery(ModelC.all, database: userDatabase.database)
+//        assertQuery(SyncMetadata.all, database: syncEngine.metadatabase) {
+//          """
+//          ┌──────────────────────────────────────────────────────────────────────────────────────────────┐
+//          │ SyncMetadata(                                                                                │
+//          │   recordPrimaryKey: "1",                                                                     │
+//          │   recordType: "modelAs",                                                                     │
+//          │   recordName: "1:modelAs",                                                                   │
+//          │   parentRecordPrimaryKey: nil,                                                               │
+//          │   parentRecordType: nil,                                                                     │
+//          │   parentRecordName: nil,                                                                     │
+//          │   lastKnownServerRecord: CKRecord(                                                           │
+//          │     recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),                                  │
+//          │     recordType: "modelAs",                                                                   │
+//          │     parent: nil,                                                                             │
+//          │     share: nil                                                                               │
+//          │   ),                                                                                         │
+//          │   _lastKnownServerRecordAllFields: CKRecord(                                                 │
+//          │     recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),                                  │
+//          │     recordType: "modelAs",                                                                   │
+//          │     parent: nil,                                                                             │
+//          │     share: nil,                                                                              │
+//          │     count: 42,                                                                               │
+//          │     id: 1                                                                                    │
+//          │   ),                                                                                         │
+//          │   share: nil,                                                                                │
+//          │   _isDeleted: false,                                                                         │
+//          │   hasLastKnownServerRecord: true,                                                            │
+//          │   isShared: false,                                                                           │
+//          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                       │
+//          │ )                                                                                            │
+//          ├──────────────────────────────────────────────────────────────────────────────────────────────┤
+//          │ SyncMetadata(                                                                                │
+//          │   recordPrimaryKey: "2",                                                                     │
+//          │   recordType: "modelAs",                                                                     │
+//          │   recordName: "2:modelAs",                                                                   │
+//          │   parentRecordPrimaryKey: nil,                                                               │
+//          │   parentRecordType: nil,                                                                     │
+//          │   parentRecordName: nil,                                                                     │
+//          │   lastKnownServerRecord: CKRecord(                                                           │
+//          │     recordID: CKRecord.ID(2:modelAs/external.zone/external.owner),                           │
+//          │     recordType: "modelAs",                                                                   │
+//          │     parent: nil,                                                                             │
+//          │     share: CKReference(recordID: CKRecord.ID(share-2:modelAs/external.zone/external.owner))  │
+//          │   ),                                                                                         │
+//          │   _lastKnownServerRecordAllFields: CKRecord(                                                 │
+//          │     recordID: CKRecord.ID(2:modelAs/external.zone/external.owner),                           │
+//          │     recordType: "modelAs",                                                                   │
+//          │     parent: nil,                                                                             │
+//          │     share: CKReference(recordID: CKRecord.ID(share-2:modelAs/external.zone/external.owner)), │
+//          │     count: 1729,                                                                             │
+//          │     id: 2                                                                                    │
+//          │   ),                                                                                         │
+//          │   share: CKRecord(                                                                           │
+//          │     recordID: CKRecord.ID(share-2:modelAs/external.zone/external.owner),                     │
+//          │     recordType: "cloudkit.share",                                                            │
+//          │     parent: nil,                                                                             │
+//          │     share: nil                                                                               │
+//          │   ),                                                                                         │
+//          │   _isDeleted: false,                                                                         │
+//          │   hasLastKnownServerRecord: true,                                                            │
+//          │   isShared: true,                                                                            │
+//          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                       │
+//          │ )                                                                                            │
+//          └──────────────────────────────────────────────────────────────────────────────────────────────┘
+//          """
+//        }
+//        assertInlineSnapshot(of: container, as: .customDump) {
+//          """
+//          MockCloudContainer(
+//            privateCloudDatabase: MockCloudDatabase(
+//              databaseScope: .private,
+//              storage: [
+//                [0]: CKRecord(
+//                  recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),
+//                  recordType: "modelAs",
+//                  parent: nil,
+//                  share: nil,
+//                  count: 42,
+//                  id: 1
+//                )
+//              ]
+//            ),
+//            sharedCloudDatabase: MockCloudDatabase(
+//              databaseScope: .shared,
+//              storage: [
+//                [0]: CKRecord(
+//                  recordID: CKRecord.ID(share-2:modelAs/external.zone/external.owner),
+//                  recordType: "cloudkit.share",
+//                  parent: nil,
+//                  share: nil
+//                ),
+//                [1]: CKRecord(
+//                  recordID: CKRecord.ID(2:modelAs/external.zone/external.owner),
+//                  recordType: "modelAs",
+//                  parent: nil,
+//                  share: CKReference(recordID: CKRecord.ID(share-2:modelAs/external.zone/external.owner)),
+//                  count: 1729,
+//                  id: 2
+//                )
+//              ]
+//            )
+//          )
+//          """
+//        }
+//      }
     }
   }
 #endif

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -629,7 +629,9 @@
         )
         _ = try syncEngine.modifyRecords(scope: .shared, saving: [share, remindersListRecord])
         let freshShare = try syncEngine.shared.database.record(for: share.recordID) as! CKShare
-        let freshRemindersListRecord = try syncEngine.shared.database.record(for: remindersListRecord.recordID)
+        let freshRemindersListRecord = try syncEngine.shared.database.record(
+          for: remindersListRecord.recordID
+        )
 
         try await syncEngine
           .acceptShare(
@@ -910,168 +912,71 @@
         }
       }
 
-//      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-//      @Test func movesChildRecordFromPrivateParentToSharedParent() async throws {
-//        try await userDatabase.userWrite { db in
-//          try db.seed {
-//            ModelA.Draft(id: 1, count: 42)
-//            ModelB.Draft(id: 1, isOn: true, modelAID: 1)
-//            ModelC.Draft(id: 1, title: "Blob", modelBID: 1)
-//            ModelC.Draft(id: 2, title: "Blob Jr", modelBID: 1)
-//            ModelC.Draft(id: 3, title: "Blob Sr", modelBID: 1)
-//          }
-//        }
-//        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-//
-//        let externalZone = CKRecordZone(
-//          zoneID: CKRecordZone.ID(
-//            zoneName: "external.zone",
-//            ownerName: "external.owner"
-//          )
-//        )
-//        try await syncEngine.modifyRecordZones(scope: .shared, saving: [externalZone]).notify()
-//
-//        let modelARecord = CKRecord(
-//          recordType: ModelA.tableName,
-//          recordID: ModelA.recordID(for: 2, zoneID: externalZone.zoneID)
-//        )
-//        modelARecord.setValue(2, forKey: "id", at: now)
-//        modelARecord.setValue(1729, forKey: "count", at: now)
-//        let share = CKShare(
-//          rootRecord: modelARecord,
-//          shareID: CKRecord.ID(
-//            recordName: "share-\(modelARecord.recordID.recordName)",
-//            zoneID: modelARecord.recordID.zoneID
-//          )
-//        )
-//        _ = try syncEngine.modifyRecords(scope: .shared, saving: [share, modelARecord])
-//        let freshShare = try syncEngine.shared.database.record(for: share.recordID) as! CKShare
-//        let freshModelARecord = try syncEngine.shared.database.record(for: modelARecord.recordID)
-//
-//        try await syncEngine
-//          .acceptShare(
-//            metadata: ShareMetadata(
-//              containerIdentifier: container.containerIdentifier!,
-//              hierarchicalRootRecordID: freshModelARecord.recordID,
-//              rootRecord: freshModelARecord,
-//              share: freshShare
-//            )
-//          )
-//
-//        try await userDatabase.userWrite { db in
-//          try ModelB.find(1).update { $0.modelAID = 2 }.execute(db)
-//        }
-//        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
-//        try await syncEngine.processPendingRecordZoneChanges(scope: .shared)
-//
-//        assertQuery(ModelA.all, database: userDatabase.database)
-//        assertQuery(ModelB.all, database: userDatabase.database)
-//        assertQuery(ModelC.all, database: userDatabase.database)
-//        assertQuery(SyncMetadata.all, database: syncEngine.metadatabase) {
-//          """
-//          ┌──────────────────────────────────────────────────────────────────────────────────────────────┐
-//          │ SyncMetadata(                                                                                │
-//          │   recordPrimaryKey: "1",                                                                     │
-//          │   recordType: "modelAs",                                                                     │
-//          │   recordName: "1:modelAs",                                                                   │
-//          │   parentRecordPrimaryKey: nil,                                                               │
-//          │   parentRecordType: nil,                                                                     │
-//          │   parentRecordName: nil,                                                                     │
-//          │   lastKnownServerRecord: CKRecord(                                                           │
-//          │     recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),                                  │
-//          │     recordType: "modelAs",                                                                   │
-//          │     parent: nil,                                                                             │
-//          │     share: nil                                                                               │
-//          │   ),                                                                                         │
-//          │   _lastKnownServerRecordAllFields: CKRecord(                                                 │
-//          │     recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),                                  │
-//          │     recordType: "modelAs",                                                                   │
-//          │     parent: nil,                                                                             │
-//          │     share: nil,                                                                              │
-//          │     count: 42,                                                                               │
-//          │     id: 1                                                                                    │
-//          │   ),                                                                                         │
-//          │   share: nil,                                                                                │
-//          │   _isDeleted: false,                                                                         │
-//          │   hasLastKnownServerRecord: true,                                                            │
-//          │   isShared: false,                                                                           │
-//          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                       │
-//          │ )                                                                                            │
-//          ├──────────────────────────────────────────────────────────────────────────────────────────────┤
-//          │ SyncMetadata(                                                                                │
-//          │   recordPrimaryKey: "2",                                                                     │
-//          │   recordType: "modelAs",                                                                     │
-//          │   recordName: "2:modelAs",                                                                   │
-//          │   parentRecordPrimaryKey: nil,                                                               │
-//          │   parentRecordType: nil,                                                                     │
-//          │   parentRecordName: nil,                                                                     │
-//          │   lastKnownServerRecord: CKRecord(                                                           │
-//          │     recordID: CKRecord.ID(2:modelAs/external.zone/external.owner),                           │
-//          │     recordType: "modelAs",                                                                   │
-//          │     parent: nil,                                                                             │
-//          │     share: CKReference(recordID: CKRecord.ID(share-2:modelAs/external.zone/external.owner))  │
-//          │   ),                                                                                         │
-//          │   _lastKnownServerRecordAllFields: CKRecord(                                                 │
-//          │     recordID: CKRecord.ID(2:modelAs/external.zone/external.owner),                           │
-//          │     recordType: "modelAs",                                                                   │
-//          │     parent: nil,                                                                             │
-//          │     share: CKReference(recordID: CKRecord.ID(share-2:modelAs/external.zone/external.owner)), │
-//          │     count: 1729,                                                                             │
-//          │     id: 2                                                                                    │
-//          │   ),                                                                                         │
-//          │   share: CKRecord(                                                                           │
-//          │     recordID: CKRecord.ID(share-2:modelAs/external.zone/external.owner),                     │
-//          │     recordType: "cloudkit.share",                                                            │
-//          │     parent: nil,                                                                             │
-//          │     share: nil                                                                               │
-//          │   ),                                                                                         │
-//          │   _isDeleted: false,                                                                         │
-//          │   hasLastKnownServerRecord: true,                                                            │
-//          │   isShared: true,                                                                            │
-//          │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                                       │
-//          │ )                                                                                            │
-//          └──────────────────────────────────────────────────────────────────────────────────────────────┘
-//          """
-//        }
-//        assertInlineSnapshot(of: container, as: .customDump) {
-//          """
-//          MockCloudContainer(
-//            privateCloudDatabase: MockCloudDatabase(
-//              databaseScope: .private,
-//              storage: [
-//                [0]: CKRecord(
-//                  recordID: CKRecord.ID(1:modelAs/zone/__defaultOwner__),
-//                  recordType: "modelAs",
-//                  parent: nil,
-//                  share: nil,
-//                  count: 42,
-//                  id: 1
-//                )
-//              ]
-//            ),
-//            sharedCloudDatabase: MockCloudDatabase(
-//              databaseScope: .shared,
-//              storage: [
-//                [0]: CKRecord(
-//                  recordID: CKRecord.ID(share-2:modelAs/external.zone/external.owner),
-//                  recordType: "cloudkit.share",
-//                  parent: nil,
-//                  share: nil
-//                ),
-//                [1]: CKRecord(
-//                  recordID: CKRecord.ID(2:modelAs/external.zone/external.owner),
-//                  recordType: "modelAs",
-//                  parent: nil,
-//                  share: CKReference(recordID: CKRecord.ID(share-2:modelAs/external.zone/external.owner)),
-//                  count: 1729,
-//                  id: 2
-//                )
-//              ]
-//            )
-//          )
-//          """
-//        }
-//      }
+      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @Test func movesChildRecordFromPrivateParentToSharedParent() async throws {
+        try await userDatabase.userWrite { db in
+          try db.seed {
+            ModelA.Draft(id: 1, count: 42)
+            ModelB.Draft(id: 1, isOn: true, modelAID: 1)
+            ModelC.Draft(id: 1, title: "Blob", modelBID: 1)
+            ModelC.Draft(id: 2, title: "Blob Jr", modelBID: 1)
+            ModelC.Draft(id: 3, title: "Blob Sr", modelBID: 1)
+          }
+        }
+        try await syncEngine.processPendingRecordZoneChanges(scope: .private)
+
+        let externalZone = CKRecordZone(
+          zoneID: CKRecordZone.ID(
+            zoneName: "external.zone",
+            ownerName: "external.owner"
+          )
+        )
+        try await syncEngine.modifyRecordZones(scope: .shared, saving: [externalZone]).notify()
+
+        let modelARecord = CKRecord(
+          recordType: ModelA.tableName,
+          recordID: ModelA.recordID(for: 2, zoneID: externalZone.zoneID)
+        )
+        modelARecord.setValue(2, forKey: "id", at: now)
+        modelARecord.setValue(1729, forKey: "count", at: now)
+        let share = CKShare(
+          rootRecord: modelARecord,
+          shareID: CKRecord.ID(
+            recordName: "share-\(modelARecord.recordID.recordName)",
+            zoneID: modelARecord.recordID.zoneID
+          )
+        )
+        _ = try syncEngine.modifyRecords(scope: .shared, saving: [share, modelARecord])
+        let freshShare = try syncEngine.shared.database.record(for: share.recordID) as! CKShare
+        let freshModelARecord = try syncEngine.shared.database.record(for: modelARecord.recordID)
+
+        try await syncEngine
+          .acceptShare(
+            metadata: ShareMetadata(
+              containerIdentifier: container.containerIdentifier!,
+              hierarchicalRootRecordID: freshModelARecord.recordID,
+              rootRecord: freshModelARecord,
+              share: freshShare
+            )
+          )
+
+        let error = try #require(
+          await #expect(throws: DatabaseError.self) {
+            try await userDatabase.userWrite { db in
+              try ModelB.find(1).update { $0.modelAID = 2 }.execute(db)
+            }
+          }
+        )
+        #expect(
+          error.localizedDescription.contains(
+            """
+            The record '1:modelBs' was moved from zone 'zone/__defaultOwner__' to \
+            'external.zone/external.owner'. This is currently not supported in SQLiteData. To work \
+            around, delete the old record and create a new record.
+            """
+          )
+        )
+      }
     }
   }
 #endif

--- a/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SharingTests.swift
@@ -918,9 +918,6 @@
           try db.seed {
             ModelA.Draft(id: 1, count: 42)
             ModelB.Draft(id: 1, isOn: true, modelAID: 1)
-            ModelC.Draft(id: 1, title: "Blob", modelBID: 1)
-            ModelC.Draft(id: 2, title: "Blob Jr", modelBID: 1)
-            ModelC.Draft(id: 3, title: "Blob Sr", modelBID: 1)
           }
         }
         try await syncEngine.processPendingRecordZoneChanges(scope: .private)

--- a/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/SyncEngineLifecycleTests.swift
@@ -266,6 +266,58 @@
             }
           }
 
+          try await Task.sleep(for: .seconds(1))
+          assertQuery(SyncMetadata.all, database: syncEngine.metadatabase) {
+            """
+            ┌───────────────────────────────────────────────────────────────────────────┐
+            │ SyncMetadata(                                                             │
+            │   recordPrimaryKey: "1",                                                  │
+            │   recordType: "remindersLists",                                           │
+            │   recordName: "1:remindersLists",                                         │
+            │   parentRecordPrimaryKey: nil,                                            │
+            │   parentRecordType: nil,                                                  │
+            │   parentRecordName: nil,                                                  │
+            │   lastKnownServerRecord: CKRecord(                                        │
+            │     recordID: CKRecord.ID(1:remindersLists/external.zone/external.owner), │
+            │     recordType: "remindersLists",                                         │
+            │     parent: nil,                                                          │
+            │     share: nil                                                            │
+            │   ),                                                                      │
+            │   _lastKnownServerRecordAllFields: CKRecord(                              │
+            │     recordID: CKRecord.ID(1:remindersLists/external.zone/external.owner), │
+            │     recordType: "remindersLists",                                         │
+            │     parent: nil,                                                          │
+            │     share: nil,                                                           │
+            │     id: 1,                                                                │
+            │     isCompleted: 0,                                                       │
+            │     title: "Personal"                                                     │
+            │   ),                                                                      │
+            │   share: nil,                                                             │
+            │   _isDeleted: false,                                                      │
+            │   hasLastKnownServerRecord: true,                                         │
+            │   isShared: false,                                                        │
+            │   userModificationDate: Date(1970-01-01T00:00:00.000Z)                    │
+            │ )                                                                         │
+            ├───────────────────────────────────────────────────────────────────────────┤
+            │ SyncMetadata(                                                             │
+            │   recordPrimaryKey: "1",                                                  │
+            │   recordType: "reminders",                                                │
+            │   recordName: "1:reminders",                                              │
+            │   parentRecordPrimaryKey: "1",                                            │
+            │   parentRecordType: "remindersLists",                                     │
+            │   parentRecordName: "1:remindersLists",                                   │
+            │   lastKnownServerRecord: nil,                                             │
+            │   _lastKnownServerRecordAllFields: nil,                                   │
+            │   share: nil,                                                             │
+            │   _isDeleted: false,                                                      │
+            │   hasLastKnownServerRecord: false,                                        │
+            │   isShared: false,                                                        │
+            │   userModificationDate: Date(1970-01-01T00:01:00.000Z)                    │
+            │ )                                                                         │
+            └───────────────────────────────────────────────────────────────────────────┘
+            """
+          }
+
           try await Task.sleep(for: .seconds(0.5))
           try await syncEngine.start()
           try await syncEngine.processPendingRecordZoneChanges(scope: .shared)

--- a/Tests/SQLiteDataTests/CloudKitTests/TriggerTests.swift
+++ b/Tests/SQLiteDataTests/CloudKitTests/TriggerTests.swift
@@ -57,7 +57,11 @@
                   SELECT "ancestorMetadatas"."lastKnownServerRecord"
                   FROM "ancestorMetadatas"
                   WHERE ("ancestorMetadatas"."parentRecordName" IS NULL)
-                )));
+                )), (
+                  SELECT "sqlitedata_icloud_metadata"."lastKnownServerRecord"
+                  FROM "sqlitedata_icloud_metadata"
+                  WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."parentRecordPrimaryKey") AND ("sqlitedata_icloud_metadata"."recordType" IS "new"."parentRecordType"))
+                ), "new"."parentRecordPrimaryKey", "new"."parentRecordType");
               END
               """,
               [2]: """
@@ -79,7 +83,11 @@
                   SELECT "ancestorMetadatas"."lastKnownServerRecord"
                   FROM "ancestorMetadatas"
                   WHERE ("ancestorMetadatas"."parentRecordName" IS NULL)
-                )));
+                )), (
+                  SELECT "sqlitedata_icloud_metadata"."lastKnownServerRecord"
+                  FROM "sqlitedata_icloud_metadata"
+                  WHERE (("sqlitedata_icloud_metadata"."recordPrimaryKey" IS "new"."parentRecordPrimaryKey") AND ("sqlitedata_icloud_metadata"."recordType" IS "new"."parentRecordType"))
+                ), "new"."parentRecordPrimaryKey", "new"."parentRecordType");
               END
               """,
               [3]: """


### PR DESCRIPTION
We don't currently support moving a record from one zone to another (e.g. moving a reminder out of a shared list and into a private list, or vice-versa). We would like to support it eventually, but for now when we detect this situation we will throw an error.