### PR TITLE
Perform multiple upserts in a single transaction.

### DIFF
--- a/Sources/SQLiteData/CloudKit/SyncEngine.swift
+++ b/Sources/SQLiteData/CloudKit/SyncEngine.swift
@@ -1259,20 +1259,24 @@
         case share(CKShare)
         case reference(CKShare.Reference)
       }
-      var shares: [ShareOrReference] = []
-      for record in modifications {
-        if let share = record as? CKShare {
-          shares.append(.share(share))
-        } else {
-          await upsertFromServerRecord(record)
-          if let shareReference = record.share {
-            shares.append(.reference(shareReference))
+      let shares = LockIsolated<[ShareOrReference]>([])
+      await withErrorReporting(.sqliteDataCloudKitFailure) {
+        try await userDatabase.write { db in
+          for record in modifications {
+            if let share = record as? CKShare {
+              shares.withValue { $0.append(.share(share)) }
+            } else {
+              upsertFromServerRecord(record, db: db)
+              if let shareReference = record.share {
+                shares.withValue { $0.append(.reference(shareReference)) }
+              }
+            }
           }
         }
       }
 
       await withTaskGroup(of: Void.self) { group in
-        for share in shares {
+        for share in shares.withValue(\.self) {
           group.addTask {
             switch share {
             case .share(let share):
@@ -1495,93 +1499,96 @@
       force: Bool = false
     ) async {
       await withErrorReporting(.sqliteDataCloudKitFailure) {
+        try await userDatabase.write { db in
+          upsertFromServerRecord(serverRecord, force: force, db: db)
+        }
+      }
+    }
+
+    private func upsertFromServerRecord(
+      _ serverRecord: CKRecord,
+      force: Bool = false,
+      db: Database
+    ) {
+      withErrorReporting(.sqliteDataCloudKitFailure) {
         guard let table = tablesByName[serverRecord.recordType]
         else {
           guard let recordPrimaryKey = serverRecord.recordID.recordPrimaryKey
           else { return }
-          try await userDatabase.write { db in
-            try SyncMetadata.insert {
-              SyncMetadata(
-                recordPrimaryKey: recordPrimaryKey,
-                recordType: serverRecord.recordType,
-                parentRecordPrimaryKey: serverRecord.parent?.recordID.recordPrimaryKey,
-                parentRecordType: serverRecord.parent?.recordID.tableName,
-                lastKnownServerRecord: serverRecord,
-                _lastKnownServerRecordAllFields: serverRecord,
-                share: nil,
-                userModificationDate: serverRecord.userModificationDate
-              )
-            } onConflict: {
-              ($0.recordPrimaryKey, $0.recordType)
-            } doUpdate: {
-              $0.setLastKnownServerRecord(serverRecord)
-            }
-            .execute(db)
+          try SyncMetadata.insert {
+            SyncMetadata(
+              recordPrimaryKey: recordPrimaryKey,
+              recordType: serverRecord.recordType,
+              parentRecordPrimaryKey: serverRecord.parent?.recordID.recordPrimaryKey,
+              parentRecordType: serverRecord.parent?.recordID.tableName,
+              lastKnownServerRecord: serverRecord,
+              _lastKnownServerRecordAllFields: serverRecord,
+              share: nil,
+              userModificationDate: serverRecord.userModificationDate
+            )
+          } onConflict: {
+            ($0.recordPrimaryKey, $0.recordType)
+          } doUpdate: {
+            $0.setLastKnownServerRecord(serverRecord)
           }
+          .execute(db)
           return
         }
 
-        let metadata = try await metadatabase.read { db in
-          try SyncMetadata
-            .where { $0.recordName.eq(serverRecord.recordID.recordName) }
-            .fetchOne(db)
-        }
+        let metadata = try SyncMetadata
+          .where { $0.recordName.eq(serverRecord.recordID.recordName) }
+          .fetchOne(db)
         serverRecord.userModificationDate =
-          metadata?.userModificationDate ?? serverRecord.userModificationDate
+        metadata?.userModificationDate ?? serverRecord.userModificationDate
 
-        func open<T: PrimaryKeyedTable>(_: T.Type) async throws {
+        func open<T: PrimaryKeyedTable>(_: T.Type) throws {
           let columnNames: [String]
           if !force, let metadata, let allFields = metadata._lastKnownServerRecordAllFields {
-            columnNames = try await userDatabase.read { db in
-              var columnNames = T.TableColumns.writableColumns.map(\.name)
-              let row = try T.find(#sql("\(bind: metadata.recordPrimaryKey)")).fetchOne(db)
-              guard let row
-              else {
-                reportIssue(
-                  """
-                  Local database record could not be found for '\(serverRecord.recordID.recordName)'.
-                  """
-                )
-                return columnNames
-              }
+            var _columnNames = T.TableColumns.writableColumns.map(\.name)
+            let row = try T.find(#sql("\(bind: metadata.recordPrimaryKey)")).fetchOne(db)
+            if let row {
               serverRecord.update(
                 with: allFields,
                 row: T(queryOutput: row),
-                columnNames: &columnNames,
+                columnNames: &_columnNames,
                 parentForeignKey: foreignKeysByTableName[T.tableName]?.count == 1
-                  ? foreignKeysByTableName[T.tableName]?.first
-                  : nil
+                ? foreignKeysByTableName[T.tableName]?.first
+                : nil
               )
-              return columnNames
+            } else {
+              reportIssue(
+                  """
+                  Local database record could not be found for '\(serverRecord.recordID.recordName)'.
+                  """
+              )
             }
+            columnNames = _columnNames
           } else {
             columnNames = T.TableColumns.writableColumns.map(\.name)
           }
 
-          try await userDatabase.write { db in
-            do {
-              try #sql(upsert(T.self, record: serverRecord, columnNames: columnNames)).execute(db)
-              try UnsyncedRecordID.find(serverRecord.recordID).delete().execute(db)
-              try SyncMetadata
-                .where { $0.recordName.eq(serverRecord.recordID.recordName) }
-                .update { $0.setLastKnownServerRecord(serverRecord) }
-                .execute(db)
-            } catch {
-              guard
-                let error = error as? DatabaseError,
-                error.resultCode == .SQLITE_CONSTRAINT,
-                error.extendedResultCode == .SQLITE_CONSTRAINT_FOREIGNKEY
-              else {
-                throw error
-              }
-              try UnsyncedRecordID.insert(or: .ignore) {
-                UnsyncedRecordID(recordID: serverRecord.recordID)
-              }
+          do {
+            try #sql(upsert(T.self, record: serverRecord, columnNames: columnNames)).execute(db)
+            try UnsyncedRecordID.find(serverRecord.recordID).delete().execute(db)
+            try SyncMetadata
+              .where { $0.recordName.eq(serverRecord.recordID.recordName) }
+              .update { $0.setLastKnownServerRecord(serverRecord) }
               .execute(db)
+          } catch {
+            guard
+              let error = error as? DatabaseError,
+              error.resultCode == .SQLITE_CONSTRAINT,
+              error.extendedResultCode == .SQLITE_CONSTRAINT_FOREIGNKEY
+            else {
+              throw error
             }
+            try UnsyncedRecordID.insert(or: .ignore) {
+              UnsyncedRecordID(recordID: serverRecord.recordID)
+            }
+            .execute(db)
           }
         }
-        try await open(table)
+        try open(table)
       }
     }
 


### PR DESCRIPTION
Right now when we receive a batch of records from CloudKit we upsert each one individually in a separate transaction. This groups them into a single transaction.