### PR TITLE
Fix Examples/README: project reference

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -2,8 +2,8 @@
 
 This directory holds many case studies and applications to demonstrate solving various problems 
 with [SharingGRDB](http://github.com/pointfreeco/sharing-grdb). Open the 
-`SharingGRDB.xcworkspace` at the root of the repo to see all example projects in one single 
-workspace, or you can open each example application individually.
+`Examples.xcodeproj` to see all example projects in a single 
+project. To work on each example app individually, select its scheme in Xcode.
 
 * **Case Studies**
   <br> Demonstrates how to solve some common application problems in an isolated environment, in 

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,7 +1,7 @@
 # Examples
 
 This directory holds many case studies and applications to demonstrate solving various problems 
-with [SharingGRDB](http://github.com/pointfreeco/sharing-grdb). Open the 
+with [SharingGRDB](https://github.com/pointfreeco/sharing-grdb). Open the 
 `Examples.xcodeproj` to see all example projects in a single 
 project. To work on each example app individually, select its scheme in Xcode.
 


### PR DESCRIPTION
- Replace the removed `SharingGRDB.xcworkspace` reference with `Examples.xcodeproj`.
- Explain that each example app is worked on individually by selecting its scheme in Xcode.
- Replace http with https (SharingGRDB link)
